### PR TITLE
API docs record consent with user ID

### DIFF
--- a/docs/api-reference/consents/create-consent.mdx
+++ b/docs/api-reference/consents/create-consent.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /consents
+---

--- a/mint.json
+++ b/mint.json
@@ -155,6 +155,7 @@
       "group": "Consents",
       "pages": [
         "docs/api-reference/consents/list-consents",
+        "docs/api-reference/consents/create-consent",
         "docs/api-reference/consents/get-consent"
       ]
     },

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -428,7 +428,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  # consents endpoints - index & GET
+  # consents endpoints - index, POST & GET
   /consents:
     get:
       summary: List consents
@@ -468,6 +468,33 @@ paths:
                   pagination:
                     type: object
                     $ref: "#/components/schemas/Pagination"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    post:
+      summary: Create a Consent
+      description: Create a new consent record
+      operationId: createConsent
+      tags:
+        - Consents
+      requestBody:
+        description: Consent to create
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConsentWrite"
+      responses:
+        "201":
+          description: Created consent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Consent"
         default:
           description: unexpected error
           content:
@@ -1201,15 +1228,9 @@ components:
           - cookie2
         created_at: "2023-01-20T12:50:00Z"
 
-    Consent:
+    ConsentWrite:
       type: object
       properties:
-        id:
-          type: string
-          description: Unique identifier for the consent
-        session_id:
-          type: string
-          description: ID of the session
         user_id:
           type: string
           description: ID of the user set by your website
@@ -1248,6 +1269,20 @@ components:
                 type: array
                 items:
                   type: string
+      required:
+        - user_preferences
+
+    Consent:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/ConsentWrite"
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the consent
+        session_id:
+          type: string
+          description: ID of the session
         created_at:
           type: string
           format: date-time


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit a960490d2dea26699274c8f8ad88a2a601657fb7.  | 
|--------|--------|

### Summary:
This PR introduces a new API endpoint for creating consent records, updates the corresponding API documentation, and modifies the navigation in the `mint.json` file.

**Key points**:
- Added a new API endpoint `POST /consents` for creating consent records.
- Updated the `openapi.yaml` file to define the new endpoint, request body schema (`ConsentWrite`), and response schemas (`Consent`).
- Updated the API documentation (`/docs/api-reference/consents/create-consent.mdx`) and the navigation in the `mint.json` file to include the new endpoint.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
