### PR TITLE
Fix consent event name

### DIFF
--- a/docs/advanced/callbacks-events.mdx
+++ b/docs/advanced/callbacks-events.mdx
@@ -26,12 +26,12 @@ window.addEventListener("cc:onFirstConsent", function (event) {
 });
 ```
 
-### `cc:onConsent`
+### `cc:onConsented`
 
 This event is triggered the very first time the user expresses their choice of consent — just like `onFirstConsent` — but also on every subsequent page load.
 
 ```js
-window.addEventListener("cc:onConsent", function (event) {
+window.addEventListener("cc:onConsented", function (event) {
   var detail = event.detail;
   // detail.cookie
 
@@ -39,12 +39,12 @@ window.addEventListener("cc:onConsent", function (event) {
 });
 ```
 
-### `cc:onChange`
+### `cc:onUpdate`
 
 This event is triggered when the user modifies their preferences and only if consent has already been provided.
 
 ```js
-window.addEventListener("cc:onChange", function (event) {
+window.addEventListener("cc:onUpdate", function (event) {
   var detail = event.detail;
   /**
    * detail.cookie

--- a/docs/installation/single-page-applications.mdx
+++ b/docs/installation/single-page-applications.mdx
@@ -46,10 +46,10 @@ If you are using [Turbo](https://turbo.hotwired.dev/handbook/building#persisting
 
 ## Callbacks & Events
 
-The `cc:onConsent` event can be used to execute code based on user consent.
+The `cc:onConsented` event can be used to execute code based on user consent.
 
 ```javascript
-window.addEventListener("cc:onConsent", function (event) {
+window.addEventListener("cc:onConsented", function (event) {
   if (CookieConsent.acceptedCategory("analytics")) {
     // "analytics" category enabled
   }
@@ -60,10 +60,10 @@ window.addEventListener("cc:onConsent", function (event) {
 });
 ```
 
-The `cc:onChange` event can be used to execute code when the user changes their consent.
+The `cc:onUpdate` event can be used to execute code when the user changes their consent.
 
 ```javascript
-window.addEventListener("cc:onChange", function (event) {
+window.addEventListener("cc:onUpdate", function (event) {
   var detail = event.detail;
 
   /**


### PR DESCRIPTION
## Summary
- update event name to `cc:onConsented`
- rename `cc:onChange` to `cc:onUpdate`

## Testing
- `grep -R "cc:onConsented" -n | head`
- `grep -R "cc:onUpdate" -n | head`

------
https://chatgpt.com/codex/tasks/task_e_688288cb5778832788ea009f7f3d21d4