### PR TITLE
Add cc:beforeModalShow event documentation

### DIFF
--- a/advanced/callbacks-events.mdx
+++ b/advanced/callbacks-events.mdx
@@ -58,6 +58,31 @@ window.addEventListener("cc:onUpdate", function (event) {
 
 ### Modal Events
 
+### `cc:beforeModalShow`
+
+Dispatched right before the consent modal is shown. This event is **cancelable** — call `event.preventDefault()` to prevent the banner from appearing. You can then show it later programmatically via `CookieChimp.show(true)`.
+
+```js
+window.addEventListener("cc:beforeModalShow", function (event) {
+  var detail = event.detail;
+  /**
+   * detail.modalName
+   */
+
+  // Example: prevent the banner from showing automatically
+  event.preventDefault();
+
+  // ... and show it later when you're ready
+  // CookieChimp.show(true);
+});
+```
+
+<Tip>
+  This is useful when you want to delay the consent banner — for example, to
+  wait until a user has completed onboarding, or to show it only after a certain
+  interaction.
+</Tip>
+
 ### `cc:onModalShow`
 
 The consent modal is visible.


### PR DESCRIPTION
## Summary
Added documentation for the `cc:beforeModalShow` event, a new cancelable event that fires right before the consent modal is displayed.

## Changes
- Documented the `cc:beforeModalShow` event with full details on its cancelable nature
- Added code example showing how to prevent the banner from appearing using `event.preventDefault()`
- Included example of programmatically showing the banner later via `CookieChimp.show(true)`
- Added a tip section explaining use cases for delaying the consent banner (e.g., waiting for onboarding completion or specific user interactions)

## Implementation Details
The event is positioned in the "Modal Events" section of the callbacks-events documentation, right before the existing `cc:onModalShow` event. This allows developers to intercept and control the modal display flow, providing flexibility in when and how the consent banner is presented to users.

https://claude.ai/code/session_01KwGrEp1UbgkURzvDMAaZuS