### PR TITLE
Expand platform-specific installation docs

### DIFF
--- a/_snippets/install/account-id-prerequisites.mdx
+++ b/_snippets/install/account-id-prerequisites.mdx
@@ -1,0 +1,3 @@
+<Info>
+  **Before you start**: have your CookieChimp **Account ID** ready (replace `YOUR_ACCOUNT_ID` in the snippets below). If you're testing on `localhost`, add `localhost` to **Additional Domains** in your Account Settings — otherwise the banner won't show locally.
+</Info>

--- a/_snippets/install/callbacks-events-link.mdx
+++ b/_snippets/install/callbacks-events-link.mdx
@@ -1,0 +1,1 @@
+For all available events, see [Callbacks & Events](/advanced/callbacks-events).

--- a/_snippets/install/cms-block-scripts-step.mdx
+++ b/_snippets/install/cms-block-scripts-step.mdx
@@ -1,0 +1,1 @@
+To stay compliant with GDPR and other privacy regulations, you need to actively block non-essential scripts and cookies until the user gives consent. See our [Scripts Management Section](/block-scripts-cookies/script-attributes) for full details.

--- a/_snippets/install/cms-copy-snippet-step.mdx
+++ b/_snippets/install/cms-copy-snippet-step.mdx
@@ -1,0 +1,7 @@
+Log in to your [CookieChimp dashboard](https://app.cookiechimp.com) and copy your website's JS snippet:
+
+```html
+<script src="https://cookiechimp.com/widget/abc123.js"></script>
+```
+
+Replace `abc123` with your website's unique CookieChimp ID.

--- a/_snippets/install/cms-preferences-step.mdx
+++ b/_snippets/install/cms-preferences-step.mdx
@@ -1,0 +1,9 @@
+CookieChimp provides a floating privacy icon (Privacy Trigger) that lets users manage cookie preferences at any time. Enable it in the banner settings.
+
+To open the preferences modal from a custom button or link, add the data attribute `data-cc="show-preferencesModal"`:
+
+```html
+<button type="button" data-cc="show-preferencesModal">
+  Manage cookie preferences
+</button>
+```

--- a/_snippets/install/cms-troubleshooting-footer.mdx
+++ b/_snippets/install/cms-troubleshooting-footer.mdx
@@ -1,0 +1,5 @@
+- Enable **Debug mode** from the CookieChimp dashboard and check the browser JS console for errors.
+
+<Note>
+  If you encounter any issues or need further assistance, please reach out to us via our chat.
+</Note>

--- a/_snippets/install/replace-account-id.mdx
+++ b/_snippets/install/replace-account-id.mdx
@@ -1,0 +1,3 @@
+<Warning>
+  Replace `YOUR_ACCOUNT_ID` with your actual CookieChimp Account ID from your dashboard.
+</Warning>

--- a/_snippets/install/script-first-warning.mdx
+++ b/_snippets/install/script-first-warning.mdx
@@ -1,0 +1,3 @@
+<Info>
+  The CookieChimp script needs to be the **first script** in the `<head>` section so it can block other scripts before they run and set cookies without consent. If other scripts are added before, they may set cookies and other storage items before consent is granted.
+</Info>

--- a/_snippets/install/service-category-note.mdx
+++ b/_snippets/install/service-category-note.mdx
@@ -1,0 +1,3 @@
+<Info>
+  Replace `"Google Analytics"` and `"analytics"` with the **exact service** and **category** names you configured in CookieChimp.
+</Info>

--- a/_snippets/install/spa-troubleshooting-base.mdx
+++ b/_snippets/install/spa-troubleshooting-base.mdx
@@ -1,0 +1,2 @@
+- **Banner doesn't appear at all** — confirm `localhost` (or your domain) is in **Additional Domains** in Account Settings.
+- Enable **Debug mode** in the CookieChimp dashboard and check the browser console for logs.

--- a/docs.json
+++ b/docs.json
@@ -41,9 +41,18 @@
             "pages": [
               "installation/google-tag-manager",
               "installation/nextjs",
-              "installation/shopify",
+              "installation/react",
+              "installation/remix",
+              "installation/nuxt",
+              "installation/angular",
+              "installation/astro",
+              "installation/sveltekit",
               "installation/single-page-applications",
+              "installation/shopify",
               "installation/wordpress",
+              "installation/webflow",
+              "installation/squarespace",
+              "installation/wix",
               "installation/adobe-launch"
             ]
           },

--- a/installation/angular.mdx
+++ b/installation/angular.mdx
@@ -1,0 +1,141 @@
+---
+title: "Angular"
+description: "Install a consent banner in an Angular application."
+icon: "angular"
+---
+
+Angular apps are typically single-page applications powered by the Angular Router. CookieChimp installs in `index.html` and reinitializes on route changes via the Router event stream.
+
+<Snippet file="install/account-id-prerequisites.mdx" />
+
+---
+
+## How do I load the CookieChimp script?
+
+Add the script tag to `src/index.html` inside `<head>`, before Angular's bundle is injected:
+
+```html
+<!-- src/index.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>My App</title>
+    <script src="https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js"></script>
+    <base href="/" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>
+```
+
+<Snippet file="install/replace-account-id.mdx" />
+
+---
+
+## How do I handle client-side navigation?
+
+Angular Router replaces the view without a full page reload. Listen to `NavigationEnd` events and reinitialize the CookieChimp widget.
+
+If you're using a **standalone component** root (Angular 17+):
+
+```ts
+// src/app/app.component.ts
+import { Component, inject, OnInit } from "@angular/core";
+import { Router, NavigationEnd, RouterOutlet } from "@angular/router";
+import { filter } from "rxjs";
+
+declare global {
+  interface Window {
+    CookieChimp?: { reinitialize?: () => void };
+  }
+}
+
+@Component({
+  selector: "app-root",
+  standalone: true,
+  imports: [RouterOutlet],
+  template: `
+    <div id="cookiechimp-container"></div>
+    <router-outlet />
+  `,
+})
+export class AppComponent implements OnInit {
+  private router = inject(Router);
+
+  ngOnInit() {
+    this.router.events
+      .pipe(filter((e) => e instanceof NavigationEnd))
+      .subscribe(() => {
+        window.CookieChimp?.reinitialize?.();
+      });
+  }
+}
+```
+
+For an `NgModule`-based app, place the same logic in your `AppComponent`'s `ngOnInit`.
+
+---
+
+## How do I check consent status in code?
+
+Wrap the CookieChimp event listeners in an Angular service so any component can subscribe:
+
+```ts
+// src/app/consent.service.ts
+import { Injectable, NgZone } from "@angular/core";
+import { BehaviorSubject } from "rxjs";
+
+declare global {
+  interface Window {
+    CookieConsent?: {
+      acceptedService?: (service: string, category: string) => boolean;
+    };
+  }
+}
+
+@Injectable({ providedIn: "root" })
+export class ConsentService {
+  private readonly state = new BehaviorSubject<Record<string, boolean>>({});
+  readonly state$ = this.state.asObservable();
+
+  constructor(private zone: NgZone) {
+    const update = () => {
+      this.zone.run(() => {
+        this.state.next({
+          analytics: !!window.CookieConsent?.acceptedService?.("Google Analytics", "analytics"),
+        });
+      });
+    };
+
+    update();
+    window.addEventListener("cc:onConsented", update);
+    window.addEventListener("cc:onUpdate", update);
+  }
+}
+```
+
+Use it in a component:
+
+```ts
+constructor(private consent: ConsentService) {}
+
+ngOnInit() {
+  this.consent.state$.subscribe((s) => {
+    console.log(s.analytics ? "✅ analytics allowed" : "❌ analytics blocked");
+  });
+}
+```
+
+<Snippet file="install/service-category-note.mdx" />
+
+<Snippet file="install/callbacks-events-link.mdx" />
+
+---
+
+## Troubleshooting
+
+- **Banner shows on first load but not after navigation** — make sure the `NavigationEnd` subscription is in your root component's `ngOnInit`, not a lazy-loaded module.
+- **Change detection issues with consent state** — wrap state updates inside `NgZone.run()` (shown above) so Angular re-renders.
+<Snippet file="install/spa-troubleshooting-base.mdx" />

--- a/installation/angular.mdx
+++ b/installation/angular.mdx
@@ -36,7 +36,7 @@ Add the script tag to `src/index.html` inside `<head>`, before Angular's bundle 
 
 ## How do I handle client-side navigation?
 
-Angular Router replaces the view without a full page reload. Listen to `NavigationEnd` events and reinitialize the CookieChimp widget.
+Angular Router replaces the view without a full page reload. Listen to `NavigationEnd` events and re-inject the CookieChimp script so it rescans the new route's DOM. The static `<script>` tag in `index.html` handles the first load, so we skip the initial event.
 
 If you're using a **standalone component** root (Angular 17+):
 
@@ -44,13 +44,7 @@ If you're using a **standalone component** root (Angular 17+):
 // src/app/app.component.ts
 import { Component, inject, OnInit } from "@angular/core";
 import { Router, NavigationEnd, RouterOutlet } from "@angular/router";
-import { filter } from "rxjs";
-
-declare global {
-  interface Window {
-    CookieChimp?: { reinitialize?: () => void };
-  }
-}
+import { filter, skip } from "rxjs";
 
 @Component({
   selector: "app-root",
@@ -66,9 +60,17 @@ export class AppComponent implements OnInit {
 
   ngOnInit() {
     this.router.events
-      .pipe(filter((e) => e instanceof NavigationEnd))
+      .pipe(
+        filter((e) => e instanceof NavigationEnd),
+        skip(1), // initial navigation is handled by the static <script> tag
+      )
       .subscribe(() => {
-        window.CookieChimp?.reinitialize?.();
+        document.getElementById("cookiechimp-js")?.remove();
+
+        const script = document.createElement("script");
+        script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
+        script.id = "cookiechimp-js";
+        document.head.appendChild(script);
       });
   }
 }

--- a/installation/astro.mdx
+++ b/installation/astro.mdx
@@ -37,7 +37,7 @@ The `is:inline` directive tells Astro not to bundle, hash, or process the script
 
 ## How do I install CookieChimp with View Transitions?
 
-If your site uses Astro's `<ClientRouter />` (Astro 5+) or `<ViewTransitions />` (Astro 3-4), navigation happens **client-side** without a full reload. You need to reinitialize the CookieChimp widget after every transition.
+If your site uses Astro's `<ClientRouter />` (Astro 5+) or `<ViewTransitions />` (Astro 3-4), navigation happens **client-side** without a full reload. Re-inject the CookieChimp script after every transition so it rescans the newly rendered page. `astro:page-load` fires on the first page load as well, so this single handler covers both cases — no separate static script tag needed.
 
 ```astro
 ---
@@ -49,12 +49,9 @@ import { ClientRouter } from "astro:transitions";
     <ClientRouter />
     <script is:inline>
       function runCookieChimp() {
-        // Don't re-inject if the script is already on the page.
-        if (document.getElementById("cookiechimp-js")) {
-          // @ts-ignore
-          window.CookieChimp?.reinitialize?.();
-          return;
-        }
+        // Remove any previous CookieChimp script before appending a fresh one
+        // so we don't accumulate stale tags across navigations.
+        document.getElementById("cookiechimp-js")?.remove();
 
         var script = document.createElement("script");
         script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";

--- a/installation/astro.mdx
+++ b/installation/astro.mdx
@@ -1,0 +1,124 @@
+---
+title: "Astro"
+description: "Install a consent banner in an Astro site, with or without View Transitions."
+icon: "rocket"
+---
+
+Astro builds static-by-default sites, but the install pattern depends on whether you're using **View Transitions**. With View Transitions enabled, Astro behaves like a single-page app and the script needs to be reinitialized on each navigation. Without them, a standard script tag is enough.
+
+<Snippet file="install/account-id-prerequisites.mdx" />
+
+---
+
+## How do I install CookieChimp in a standard Astro site?
+
+If you're **not** using `<ClientRouter />` (formerly `<ViewTransitions />`), every navigation is a full page load — a single script tag in your root layout works:
+
+```astro
+---
+// src/layouts/Layout.astro
+---
+<html lang="en">
+  <head>
+    <script is:inline src="https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js"></script>
+    <slot name="head" />
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>
+```
+
+<Snippet file="install/replace-account-id.mdx" />
+
+The `is:inline` directive tells Astro not to bundle, hash, or process the script — it ships exactly as written so it runs as the first thing in `<head>`.
+
+---
+
+## How do I install CookieChimp with View Transitions?
+
+If your site uses Astro's `<ClientRouter />` (Astro 5+) or `<ViewTransitions />` (Astro 3-4), navigation happens **client-side** without a full reload. You need to reinitialize the CookieChimp widget after every transition.
+
+```astro
+---
+// src/layouts/Layout.astro
+import { ClientRouter } from "astro:transitions";
+---
+<html lang="en">
+  <head>
+    <ClientRouter />
+    <script is:inline>
+      function runCookieChimp() {
+        // Don't re-inject if the script is already on the page.
+        if (document.getElementById("cookiechimp-js")) {
+          // @ts-ignore
+          window.CookieChimp?.reinitialize?.();
+          return;
+        }
+
+        var script = document.createElement("script");
+        script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
+        script.id = "cookiechimp-js";
+        document.head.appendChild(script);
+      }
+
+      // Fires on the first page load AND after every view transition.
+      document.addEventListener("astro:page-load", runCookieChimp);
+    </script>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>
+```
+
+---
+
+## How do I position the Privacy Trigger?
+
+Add a `<div id="cookiechimp-container">` somewhere in your layout, and mark it with `transition:persist` so View Transitions don't tear it down between routes:
+
+```astro
+<!-- src/layouts/Layout.astro -->
+<body>
+  <div id="cookiechimp-container" transition:persist></div>
+  <slot />
+</body>
+```
+
+See the Astro docs on [maintaining state with `transition:persist`](https://docs.astro.build/en/guides/view-transitions/#maintaining-state) for more.
+
+---
+
+## How do I run code based on consent?
+
+Inline Astro scripts run on every page (or just once with View Transitions). Listen for CookieChimp events:
+
+```astro
+<script is:inline>
+  window.addEventListener("cc:onConsented", function () {
+    if (window.CookieChimp.acceptedService("Google Analytics", "analytics")) {
+      // load your analytics SDK
+    }
+  });
+
+  window.addEventListener("cc:onUpdate", function (event) {
+    if (event.detail.changedCategories.includes("analytics")) {
+      // user toggled analytics on or off
+    }
+  });
+</script>
+```
+
+<Snippet file="install/service-category-note.mdx" />
+
+<Snippet file="install/callbacks-events-link.mdx" />
+
+---
+
+## Troubleshooting
+
+- **Banner shows on first load but disappears after navigation** — you're using View Transitions but the `astro:page-load` listener isn't wired up. Use the View Transitions install pattern above.
+- **Privacy Trigger flashes or disappears between pages** — add `transition:persist` to your `#cookiechimp-container` div.
+- **Script doesn't run first** — make sure you used `is:inline` on the script tag so Astro doesn't defer it.
+<Snippet file="install/spa-troubleshooting-base.mdx" />

--- a/installation/google-tag-manager.mdx
+++ b/installation/google-tag-manager.mdx
@@ -4,20 +4,44 @@ description: "Set up a consent banner with Google Tag Manager and Google Consent
 icon: "google"
 ---
 
-Add your website's CookieChimp JS snippet in the `<head>` tag of your HTML. 
+## How do I install the CookieChimp script?
 
-<Warning>Do not add our HTML code via Google Tag Manager since we set the default consent states before Google Tag Manager runs.</Warning>
+You can install CookieChimp two ways. **Direct HTML is the recommended approach** — it guarantees CookieChimp loads before Google Tag Manager and any other scripts, so it can set consent defaults before any tag fires.
 
-<Info>
-  The CookieChimp script needs to be added at the top of the `<head>` section, so that it can run first, in order to ensure other scripts are only run based on consent.
-  If other scripts are added before, they may set cookies and other storage items before consent is granted.
-</Info>
+<Tabs>
+  <Tab title="Direct HTML (Recommended)">
+    Add your website's CookieChimp JS snippet at the top of the `<head>` tag in your HTML, **before** the Google Tag Manager script and any other scripts.
 
-```html
-<script src="https://cookiechimp.com/widget/abc123.js"></script>
-```
+    ```html
+    <script src="https://cookiechimp.com/widget/abc123.js"></script>
+    ```
 
-You need to replace `abc123` with your website's unique CookieChimp ID.
+    Replace `abc123` with your website's unique CookieChimp ID.
+
+    <Snippet file="install/script-first-warning.mdx" />
+  </Tab>
+
+  <Tab title="Via Google Tag Manager">
+    If you can't edit your site's HTML directly, you can install CookieChimp through GTM — but you must fire it from the **Consent Initialization - All Pages** trigger so it runs before any tag sets a consent state.
+
+    <Warning>
+      When installing via GTM, you **must** use the **Consent Initialization - All Pages** trigger. This is GTM's earliest trigger type — it fires before the **Initialization** and **Page View** triggers, ensuring CookieChimp sets consent defaults before any other tags run. If you use a different trigger, other tags can fire before consent is set.
+    </Warning>
+
+    **To add CookieChimp via GTM:**
+
+    1. In your GTM workspace, create a new tag and choose **Custom HTML**.
+    2. Paste the CookieChimp script into the tag:
+
+       ```html
+       <script src="https://cookiechimp.com/widget/abc123.js"></script>
+       ```
+
+       Replace `abc123` with your website's unique CookieChimp ID.
+    3. For the trigger, select **Consent Initialization - All Pages**.
+    4. Save the tag and **publish** your container.
+  </Tab>
+</Tabs>
 
 
 ## How do I block tags with Google Tag Manager?

--- a/installation/google-tag-manager.mdx
+++ b/installation/google-tag-manager.mdx
@@ -22,10 +22,12 @@ You can install CookieChimp two ways. **Direct HTML is the recommended approach*
   </Tab>
 
   <Tab title="Via Google Tag Manager">
-    If you can't edit your site's HTML directly, you can install CookieChimp through GTM — but you must fire it from the **Consent Initialization - All Pages** trigger so it runs before any tag sets a consent state.
+    If you can't edit your site's HTML directly, you can install CookieChimp through GTM. Fire it from the **Consent Initialization - All Pages** trigger — this is the earliest trigger GTM exposes, so it gives CookieChimp the best chance of loading before other tags.
 
     <Warning>
-      When installing via GTM, you **must** use the **Consent Initialization - All Pages** trigger. This is GTM's earliest trigger type — it fires before the **Initialization** and **Page View** triggers, ensuring CookieChimp sets consent defaults before any other tags run. If you use a different trigger, other tags can fire before consent is set.
+      **This method does not guarantee strict ordering.** The Consent Initialization trigger controls when GTM **injects** the CookieChimp `<script>` tag — but the external script still has to download and execute asynchronously. On slower networks, other tags fired by Initialization or Page View triggers can run before CookieChimp has set its consent defaults, which can lead to cookies being set without consent.
+
+      If strict ordering matters (and for GDPR compliance it usually does), use the **Direct HTML** method instead.
     </Warning>
 
     **To add CookieChimp via GTM:**
@@ -40,6 +42,10 @@ You can install CookieChimp two ways. **Direct HTML is the recommended approach*
        Replace `abc123` with your website's unique CookieChimp ID.
     3. For the trigger, select **Consent Initialization - All Pages**.
     4. Save the tag and **publish** your container.
+
+    <Tip>
+      You can reduce the async-download race by configuring **Tag Sequencing** on your other tags so they wait for the CookieChimp tag to finish, or by gating downstream tags on the `cookiechimp_consent_update` custom event (covered in the section below). Direct HTML remains the most reliable option.
+    </Tip>
   </Tab>
 </Tabs>
 

--- a/installation/installation.mdx
+++ b/installation/installation.mdx
@@ -39,6 +39,34 @@ icon: "download"
   </Step>
 </Steps>
 
+## Are there platform-specific guides?
+
+Yes — pick the guide that matches your stack for tailored instructions.
+
+### JavaScript frameworks
+
+<CardGroup cols={2}>
+  <Card title="Next.js" icon="react" href="/installation/nextjs">App Router and Pages Router with `next/script`.</Card>
+  <Card title="React (Vite / CRA)" icon="react" href="/installation/react">Plain React apps with React Router.</Card>
+  <Card title="Remix" icon="react" href="/installation/remix">Server-rendered React with client navigation.</Card>
+  <Card title="Nuxt" icon="vuejs" href="/installation/nuxt">Vue framework with SSR and client routing.</Card>
+  <Card title="Angular" icon="angular" href="/installation/angular">Standalone or NgModule-based apps.</Card>
+  <Card title="Astro" icon="rocket" href="/installation/astro">Static sites, with or without View Transitions.</Card>
+  <Card title="SvelteKit" icon="code" href="/installation/sveltekit">SvelteKit's `afterNavigate` pattern.</Card>
+  <Card title="JS & SPAs (catch-all)" icon="code" href="/installation/single-page-applications">Generic SPA setup if your framework isn't above.</Card>
+</CardGroup>
+
+### CMS & hosted platforms
+
+<CardGroup cols={2}>
+  <Card title="WordPress" icon="wordpress" href="/installation/wordpress">Official plugin with WP Consent API support.</Card>
+  <Card title="Shopify" icon="shopify" href="/installation/shopify">Add the snippet to `theme.liquid`.</Card>
+  <Card title="Webflow" icon="webflow" href="/installation/webflow">Custom Code in Project Settings.</Card>
+  <Card title="Squarespace" icon="squarespace" href="/installation/squarespace">Header Code Injection.</Card>
+  <Card title="Wix" icon="globe" href="/installation/wix">Custom Code on Wix Premium plans.</Card>
+  <Card title="Google Tag Manager" icon="google" href="/installation/google-tag-manager">Direct HTML or via GTM's Consent Initialization trigger.</Card>
+</CardGroup>
+
 ## What if the banner doesn't show?
 
 - Check if the domain is allowed in the Settings page on our platform.

--- a/installation/nextjs.mdx
+++ b/installation/nextjs.mdx
@@ -60,9 +60,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 ```
 
-<Warning>
-  Replace `YOUR_ACCOUNT_ID` with your actual CookieChimp Account ID from your dashboard.
-</Warning>
+<Snippet file="install/replace-account-id.mdx" />
 
 ---
 
@@ -108,9 +106,7 @@ export default function ConsentLogger() {
 }
 ```
 
-<Info>
-  Replace `"Google Analytics"` and `"analytics"` with the **exact service** and **category** names you configured in CookieChimp.
-</Info>
+<Snippet file="install/service-category-note.mdx" />
 
 ---
 

--- a/installation/nuxt.mdx
+++ b/installation/nuxt.mdx
@@ -1,0 +1,129 @@
+---
+title: "Nuxt"
+description: "Install a consent banner in a Nuxt 3 application."
+icon: "vuejs"
+---
+
+Nuxt is the most popular Vue framework. CookieChimp installs via the `app.head` config so the script lands in `<head>` on every server-rendered page, then reinitializes on client-side navigation.
+
+<Snippet file="install/account-id-prerequisites.mdx" />
+
+---
+
+## How do I load the CookieChimp script?
+
+Add the script to `nuxt.config.ts` under `app.head.script`. Set it to render at the **top** of `<head>` so nothing else runs first.
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  app: {
+    head: {
+      script: [
+        {
+          src: "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js",
+          tagPosition: "head",
+          tagPriority: "critical",
+        },
+      ],
+    },
+  },
+});
+```
+
+<Snippet file="install/replace-account-id.mdx" />
+
+The `tagPriority: "critical"` hint asks Nuxt's `useHead` to render this script as early as possible in `<head>`, before other third-party tags.
+
+---
+
+## How do I handle client-side navigation?
+
+Nuxt uses client-side routing for in-app navigation. Create a Nuxt plugin that reinitializes the CookieChimp widget on every route change:
+
+```ts
+// plugins/cookiechimp.client.ts
+export default defineNuxtPlugin((nuxtApp) => {
+  const router = useRouter();
+
+  router.afterEach(() => {
+    // @ts-ignore
+    window.CookieChimp?.reinitialize?.();
+  });
+});
+```
+
+<Info>
+  The `.client.ts` suffix tells Nuxt to only run this plugin in the browser — `window.CookieChimp` doesn't exist during server rendering.
+</Info>
+
+---
+
+## How do I add a Privacy Trigger container?
+
+Add a `<div id="cookiechimp-container">` to your root layout (`layouts/default.vue` or `app.vue`) so it stays mounted across all pages:
+
+```vue
+<!-- app.vue -->
+<template>
+  <div>
+    <div id="cookiechimp-container"></div>
+    <NuxtPage />
+  </div>
+</template>
+```
+
+---
+
+## How do I check consent status in code?
+
+Use a composable that listens for `cc:onConsented` and `cc:onUpdate`:
+
+```ts
+// composables/useConsent.ts
+export function useConsent(service: string, category: string) {
+  const allowed = ref(false);
+
+  onMounted(() => {
+    function check() {
+      // @ts-ignore
+      allowed.value = !!window.CookieConsent?.acceptedService?.(service, category);
+    }
+
+    check();
+    window.addEventListener("cc:onConsented", check);
+    window.addEventListener("cc:onUpdate", check);
+
+    onUnmounted(() => {
+      window.removeEventListener("cc:onConsented", check);
+      window.removeEventListener("cc:onUpdate", check);
+    });
+  });
+
+  return allowed;
+}
+```
+
+Use it in a component:
+
+```vue
+<script setup lang="ts">
+const analyticsAllowed = useConsent("Google Analytics", "analytics");
+</script>
+
+<template>
+  <p v-if="analyticsAllowed">Analytics is enabled.</p>
+</template>
+```
+
+<Snippet file="install/service-category-note.mdx" />
+
+<Snippet file="install/callbacks-events-link.mdx" />
+
+---
+
+## Troubleshooting
+
+- **Banner shows on first load but not after navigation** — make sure your `cookiechimp.client.ts` plugin is in the `plugins/` directory and uses the `.client.ts` suffix.
+- **Script loads too late** — keep `tagPriority: "critical"` and make sure no other third-party scripts use a higher priority.
+<Snippet file="install/spa-troubleshooting-base.mdx" />

--- a/installation/nuxt.mdx
+++ b/installation/nuxt.mdx
@@ -39,22 +39,32 @@ The `tagPriority: "critical"` hint asks Nuxt's `useHead` to render this script a
 
 ## How do I handle client-side navigation?
 
-Nuxt uses client-side routing for in-app navigation. Create a Nuxt plugin that reinitializes the CookieChimp widget on every route change:
+Nuxt uses client-side routing for in-app navigation. Create a Nuxt plugin that re-injects the CookieChimp script on every route change so it rescans the newly mounted route's DOM. The static script from `nuxt.config.ts` handles the initial page load, so we skip the first `afterEach` call.
 
 ```ts
 // plugins/cookiechimp.client.ts
-export default defineNuxtPlugin((nuxtApp) => {
+export default defineNuxtPlugin(() => {
   const router = useRouter();
+  let isInitial = true;
 
   router.afterEach(() => {
-    // @ts-ignore
-    window.CookieChimp?.reinitialize?.();
+    if (isInitial) {
+      isInitial = false;
+      return;
+    }
+
+    document.getElementById("cookiechimp-js")?.remove();
+
+    const script = document.createElement("script");
+    script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
+    script.id = "cookiechimp-js";
+    document.head.appendChild(script);
   });
 });
 ```
 
 <Info>
-  The `.client.ts` suffix tells Nuxt to only run this plugin in the browser — `window.CookieChimp` doesn't exist during server rendering.
+  The `.client.ts` suffix tells Nuxt to only run this plugin in the browser — `document` doesn't exist during server rendering.
 </Info>
 
 ---

--- a/installation/react.mdx
+++ b/installation/react.mdx
@@ -1,0 +1,161 @@
+---
+title: "React"
+description: "Install a consent banner in a React app built with Vite or Create React App."
+icon: "react"
+---
+
+This guide covers plain React apps — bundled with **Vite** or **Create React App (CRA)**. If you're using **Next.js**, follow our [Next.js guide](/installation/nextjs). If you're using **Remix**, follow our [Remix guide](/installation/remix).
+
+<Snippet file="install/account-id-prerequisites.mdx" />
+
+---
+
+## How do I install CookieChimp in a Vite + React app?
+
+Add the script tag to `index.html` (at the project root) inside `<head>`, **before** any module scripts so it loads first:
+
+```html
+<!-- index.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js"></script>
+    <!-- Vite injects your module script here -->
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+<Warning>
+  Vite serves `index.html` as the entry point in both dev and production. The script tag goes here once — there's no separate build step needed.
+</Warning>
+
+---
+
+## How do I install CookieChimp in a Create React App?
+
+Add the script tag to `public/index.html` inside `<head>`, before any other scripts:
+
+```html
+<!-- public/index.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js"></script>
+    <!-- %PUBLIC_URL% references and other CRA tags can follow -->
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>
+```
+
+CRA injects your bundle after the HTML is served, so a static `<script>` in `<head>` runs before React mounts.
+
+---
+
+## How do I handle client-side routing (React Router)?
+
+If your app uses **React Router** (v6+), pages don't reload on navigation — they swap components. CookieChimp needs to know about route changes so it can re-evaluate which scripts to allow.
+
+Create a small component that listens to location changes and reinitializes the widget:
+
+```tsx
+// src/components/CookieChimpReinit.tsx
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function CookieChimpReinit() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    // @ts-ignore
+    window.CookieChimp?.reinitialize?.();
+  }, [pathname]);
+
+  return null;
+}
+```
+
+Mount it once at the top of your app, inside the router:
+
+```tsx
+// src/main.tsx
+import { BrowserRouter } from "react-router-dom";
+import CookieChimpReinit from "./components/CookieChimpReinit";
+import App from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <BrowserRouter>
+    <CookieChimpReinit />
+    <App />
+  </BrowserRouter>
+);
+```
+
+---
+
+## How do I add a Privacy Trigger container?
+
+Place a `<div>` with the ID `cookiechimp-container` somewhere in your layout that **doesn't unmount on navigation** — typically your root layout or `App.tsx`:
+
+```tsx
+// src/App.tsx
+export default function App() {
+  return (
+    <>
+      <div id="cookiechimp-container" />
+      {/* the rest of your app */}
+    </>
+  );
+}
+```
+
+---
+
+## How do I check consent status in code?
+
+Listen for the `cc:onConsented` event (fires once when consent has been given) and `cc:onUpdate` (fires when the user changes their preferences).
+
+```tsx
+// src/components/ConsentLogger.tsx
+import { useEffect } from "react";
+
+export default function ConsentLogger() {
+  useEffect(() => {
+    function logConsent() {
+      // @ts-ignore
+      const allowed = window.CookieConsent?.acceptedService?.("Google Analytics", "analytics");
+      console.log(allowed ? "✅ analytics allowed" : "❌ analytics blocked");
+    }
+
+    logConsent();
+    window.addEventListener("cc:onConsented", logConsent);
+    window.addEventListener("cc:onUpdate", logConsent);
+
+    return () => {
+      window.removeEventListener("cc:onConsented", logConsent);
+      window.removeEventListener("cc:onUpdate", logConsent);
+    };
+  }, []);
+
+  return null;
+}
+```
+
+<Snippet file="install/service-category-note.mdx" />
+
+<Snippet file="install/callbacks-events-link.mdx" />
+
+---
+
+## Troubleshooting
+
+- **Banner shows on first load but not after navigation** — make sure `CookieChimpReinit` is mounted **inside** `<BrowserRouter>`.
+- **Privacy Trigger disappears** — keep `#cookiechimp-container` in a layout component that stays mounted across routes.
+<Snippet file="install/spa-troubleshooting-base.mdx" />

--- a/installation/react.mdx
+++ b/installation/react.mdx
@@ -63,19 +63,31 @@ CRA injects your bundle after the HTML is served, so a static `<script>` in `<he
 
 If your app uses **React Router** (v6+), pages don't reload on navigation — they swap components. CookieChimp needs to know about route changes so it can re-evaluate which scripts to allow.
 
-Create a small component that listens to location changes and reinitializes the widget:
+Create a small component that listens to location changes and re-injects the CookieChimp script. We skip the first render because the static `<script>` tag in `index.html` has already loaded CookieChimp on initial page load.
 
 ```tsx
 // src/components/CookieChimpReinit.tsx
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
 
 export default function CookieChimpReinit() {
   const { pathname } = useLocation();
+  const isFirstRender = useRef(true);
 
   useEffect(() => {
-    // @ts-ignore
-    window.CookieChimp?.reinitialize?.();
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    // Remove the previous script tag (if any) and append a fresh one
+    // so CookieChimp rescans the newly mounted route's DOM.
+    document.getElementById("cookiechimp-js")?.remove();
+
+    const script = document.createElement("script");
+    script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
+    script.id = "cookiechimp-js";
+    document.head.appendChild(script);
   }, [pathname]);
 
   return null;

--- a/installation/remix.mdx
+++ b/installation/remix.mdx
@@ -48,21 +48,30 @@ The `suppressHydrationWarning` prop prevents React from warning about the third-
 
 ## How do I handle client-side navigation?
 
-Remix uses client-side transitions for in-app links. Reinitialize the CookieChimp widget on every navigation by listening to the location.
-
-Create a small component in `app/root.tsx` (or a separate file) and mount it once:
+Remix uses client-side transitions for in-app links. Re-inject the CookieChimp script on every navigation by listening to the location. The static `<script>` tag from server-rendered HTML handles the first load, so we skip the initial render.
 
 ```tsx
 // app/components/CookieChimpReinit.tsx
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useLocation } from "@remix-run/react";
 
 export default function CookieChimpReinit() {
   const location = useLocation();
+  const isFirstRender = useRef(true);
 
   useEffect(() => {
-    // @ts-ignore
-    window.CookieChimp?.reinitialize?.();
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    // Re-inject the CookieChimp script so it rescans the new route's DOM.
+    document.getElementById("cookiechimp-js")?.remove();
+
+    const script = document.createElement("script");
+    script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
+    script.id = "cookiechimp-js";
+    document.head.appendChild(script);
   }, [location.pathname]);
 
   return null;

--- a/installation/remix.mdx
+++ b/installation/remix.mdx
@@ -1,0 +1,126 @@
+---
+title: "Remix"
+description: "Install a consent banner in a Remix application."
+icon: "react"
+---
+
+Remix is a full-stack React framework with server rendering and client-side navigation. CookieChimp installs in your root document and re-evaluates on each client transition.
+
+<Snippet file="install/account-id-prerequisites.mdx" />
+
+---
+
+## How do I load the CookieChimp script?
+
+Add the script tag to `app/root.tsx` inside `<head>` — **before** Remix's `<Links />`, `<Meta />`, and `<Scripts />` components so it runs first:
+
+```tsx
+// app/root.tsx
+import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
+
+export default function App() {
+  return (
+    <html lang="en">
+      <head>
+        <script
+          src="https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js"
+          suppressHydrationWarning
+        />
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <div id="cookiechimp-container" />
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+      </body>
+    </html>
+  );
+}
+```
+
+<Snippet file="install/replace-account-id.mdx" />
+
+The `suppressHydrationWarning` prop prevents React from warning about the third-party script mutating `<head>` after server render.
+
+---
+
+## How do I handle client-side navigation?
+
+Remix uses client-side transitions for in-app links. Reinitialize the CookieChimp widget on every navigation by listening to the location.
+
+Create a small component in `app/root.tsx` (or a separate file) and mount it once:
+
+```tsx
+// app/components/CookieChimpReinit.tsx
+import { useEffect } from "react";
+import { useLocation } from "@remix-run/react";
+
+export default function CookieChimpReinit() {
+  const location = useLocation();
+
+  useEffect(() => {
+    // @ts-ignore
+    window.CookieChimp?.reinitialize?.();
+  }, [location.pathname]);
+
+  return null;
+}
+```
+
+Add it to your root layout:
+
+```tsx
+// app/root.tsx
+<body>
+  <div id="cookiechimp-container" />
+  <CookieChimpReinit />
+  <Outlet />
+  {/* ... */}
+</body>
+```
+
+---
+
+## How do I check consent status in code?
+
+Listen for the `cc:onConsented` and `cc:onUpdate` events inside a client-only effect:
+
+```tsx
+// app/components/ConsentLogger.tsx
+import { useEffect } from "react";
+
+export default function ConsentLogger() {
+  useEffect(() => {
+    function logConsent() {
+      // @ts-ignore
+      const allowed = window.CookieConsent?.acceptedService?.("Google Analytics", "analytics");
+      console.log(allowed ? "✅ analytics allowed" : "❌ analytics blocked");
+    }
+
+    logConsent();
+    window.addEventListener("cc:onConsented", logConsent);
+    window.addEventListener("cc:onUpdate", logConsent);
+
+    return () => {
+      window.removeEventListener("cc:onConsented", logConsent);
+      window.removeEventListener("cc:onUpdate", logConsent);
+    };
+  }, []);
+
+  return null;
+}
+```
+
+<Snippet file="install/service-category-note.mdx" />
+
+<Snippet file="install/callbacks-events-link.mdx" />
+
+---
+
+## Troubleshooting
+
+- **Hydration warnings** — make sure the CookieChimp script tag uses `suppressHydrationWarning`.
+- **Banner shows on first load but not after navigation** — verify `CookieChimpReinit` is mounted inside the `<body>` of `root.tsx`.
+<Snippet file="install/spa-troubleshooting-base.mdx" />

--- a/installation/shopify.mdx
+++ b/installation/shopify.mdx
@@ -6,13 +6,7 @@ icon: "shopify"
 
 <Steps>
   <Step title="Copy your CookieChimp snippet">
-    Log in to your [CookieChimp dashboard](https://app.cookiechimp.com) and copy your website's JS snippet. It looks like this:
-
-    ```html
-    <script src="https://cookiechimp.com/widget/abc123.js"></script>
-    ```
-
-    Replace `abc123` with your website's unique CookieChimp ID.
+    <Snippet file="install/cms-copy-snippet-step.mdx" />
   </Step>
 
   <Step title="Add the snippet to your Shopify theme">
@@ -22,36 +16,44 @@ icon: "shopify"
     4. Find the opening `<head>` tag and paste the CookieChimp snippet directly after it, before any other scripts.
     5. Click **Save**.
 
-    <Info>
-      The CookieChimp script needs to be the first script in the `<head>` section so it can block other scripts before they run and set cookies without consent.
-    </Info>
+    <Snippet file="install/script-first-warning.mdx" />
+  </Step>
+
+  <Step title="Disable Shopify's built-in cookie banner">
+    Shopify's Customer Privacy banner will conflict with CookieChimp. Turn it off:
+
+    1. Go to **Settings → Customer privacy → Cookie banner**.
+    2. Disable the cookie banner (or set it to inactive on the regions where you'll use CookieChimp).
+
+    CookieChimp now handles consent end-to-end and signals consent to Shopify's [Customer Privacy API](https://shopify.dev/docs/api/customer-privacy) so first-party Shopify pixels and Shop Pay tracking respect the user's choice.
   </Step>
 
   <Step title="Block scripts & cookies">
-    To ensure compliance with privacy regulations, you need to block non-essential scripts and cookies until the user gives consent.
-    Refer to our [Scripts Management Section](/block-scripts-cookies/script-attributes) for detailed instructions.
+    <Snippet file="install/cms-block-scripts-step.mdx" />
+
+    <Tip>
+      Common third-party tools added through Shopify apps (Klaviyo, Hotjar, TikTok Pixel, Meta Pixel, etc.) are usually injected as `<script>` tags into `theme.liquid` or via App Embed Blocks. Update those embeds with `type="text/plain"` and the matching `data-category` attribute so CookieChimp can manage them.
+    </Tip>
+  </Step>
+
+  <Step title="Configure checkout scripts (Shopify Plus)">
+    Shopify's checkout pages live on a separate domain and template. If you're on **Shopify Plus** and have edited `checkout.liquid`, repeat step 2 there as well so CookieChimp runs on the checkout flow.
+
+    <Info>
+      On non-Plus plans, Shopify renders checkout from a managed template you can't edit. Consent is enforced through the Customer Privacy API, which CookieChimp talks to automatically when installed on your storefront.
+    </Info>
   </Step>
 
   <Step title="Allow users to update their preferences">
-    CookieChimp provides a floating privacy icon (Privacy Trigger) that allows users to manage their cookie preferences at any time.
-    You can enable this in the banner settings.
+    <Snippet file="install/cms-preferences-step.mdx" />
 
-    Optionally, you can open the preferences modal with a custom link or button by adding a button with the data attribute `data-cc="show-preferencesModal"`:
-
-    ```html
-    <button type="button" data-cc="show-preferencesModal">
-      Manage cookie preferences
-    </button>
-    ```
+    A common pattern is to link to it from your footer menu — Shopify lets you add custom links to menus from **Online Store → Navigation**.
   </Step>
 </Steps>
 
 ## Troubleshooting
 
-- Make sure the domain is allowed in the Settings page on the CookieChimp dashboard.
+- Make sure the domain is allowed in the Settings page on the CookieChimp dashboard. Both your `*.myshopify.com` domain and your custom domain should be listed if you want to test on either.
+- If both Shopify's banner and CookieChimp appear, the Shopify Customer Privacy banner isn't fully disabled — re-check **Settings → Customer privacy → Cookie banner**.
 - Clear your browser cache and cookies, then reload your store.
-- Enable "Debug mode" from the CookieChimp dashboard and check the browser JS console for errors.
-
-<Note>
-  If you encounter any issues or need further assistance, please reach out to us via our chat.
-</Note>
+<Snippet file="install/cms-troubleshooting-footer.mdx" />

--- a/installation/single-page-applications.mdx
+++ b/installation/single-page-applications.mdx
@@ -1,52 +1,204 @@
 ---
 title: "JS & Single Page Apps"
-description: "Install a consent banner in JavaScript-powered SPAs like React, Astro, and more."
+description: "Install a consent banner in JavaScript-powered SPAs like Astro, Vue, React Router, SvelteKit, and more."
 icon: "react"
 ---
 
-## How do I load CookieChimp in an SPA?
+Single Page Applications (SPAs) update the URL and the visible page **without a full page reload**. Because of this, a script tag added to `<head>` only runs once — on the first load — and the CookieChimp widget can be torn down or lost when the user navigates between routes.
 
-If you are using a Single Page Application (SPA), you need to ensure to reinitialize the CookieChimp widget on page navigation. You can do this by including the CookieChimp script in the following way (example is for Astro JS):
+This page covers two things:
+
+1. **How to load the CookieChimp script so it runs on every page**, framework by framework.
+2. **How to position the Privacy Trigger** so the floating icon survives client-side navigation.
+
+<Info>
+  We have dedicated guides for the most common frameworks — they're more detailed than this overview:
+  [Next.js](/installation/nextjs) ·
+  [React (Vite/CRA)](/installation/react) ·
+  [Remix](/installation/remix) ·
+  [Nuxt](/installation/nuxt) ·
+  [Angular](/installation/angular) ·
+  [Astro](/installation/astro) ·
+  [SvelteKit](/installation/sveltekit).
+  This page is the catch-all for any SPA that doesn't have its own guide.
+</Info>
+
+---
+
+## How do I install CookieChimp in an SPA?
+
+The pattern is the same across all SPA frameworks:
+
+1. **Inject the script** into `<head>` so it loads as early as possible — ideally before the framework hydrates.
+2. **Re-initialize** the widget on every client-side route change by listening to the framework's navigation event.
+
+The exact navigation event differs per framework. Pick yours below.
+
+### Astro
+
+Astro's [View Transitions](https://docs.astro.build/en/guides/view-transitions/) emit an `astro:page-load` event after every navigation (including the first). Use `is:inline` so Astro doesn't bundle the script.
+
+Add this to your root layout — typically `src/layouts/Layout.astro` — inside `<head>`:
 
 ```html
 <script is:inline>
   function runCookieChimp() {
+    // Don't re-inject if the script is already on the page.
+    if (document.getElementById("cookiechimp-js")) return;
+
     var script = document.createElement("script");
-    script.src = "https://cookiechimp.com/widget/K8ktWD.js";
+    script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
     script.id = "cookiechimp-js";
     document.head.appendChild(script);
   }
 
-  // for Astro JS.
-  // listen for other events for different frameworks.
+  // Fires on first load AND after every Astro view transition.
   document.addEventListener("astro:page-load", runCookieChimp);
 </script>
 ```
 
+<Snippet file="install/replace-account-id.mdx" />
+
+<Tip>
+  **Not using View Transitions?** If you haven't enabled `<ViewTransitions />` in your layout, Astro performs a full page reload on each navigation — the standard `<script src="...">` install works without any re-initialization logic.
+</Tip>
+
+### Vue (Vue Router)
+
+Add the script tag in your `index.html` `<head>` and re-initialize on every route change from your router config (`src/router/index.js`):
+
+```js
+import { createRouter, createWebHistory } from "vue-router";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [/* ... */],
+});
+
+router.afterEach(() => {
+  if (typeof window.CookieChimp?.reinitialize === "function") {
+    window.CookieChimp.reinitialize();
+  }
+});
+
+export default router;
+```
+
+### React (React Router v6+)
+
+Add the script tag in your `index.html` `<head>`, then create a tiny component that listens to location changes and mount it once at the top of your tree:
+
+```tsx
+// src/components/CookieChimpReinit.tsx
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function CookieChimpReinit() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    // @ts-ignore
+    window.CookieChimp?.reinitialize?.();
+  }, [pathname]);
+
+  return null;
+}
+```
+
+```tsx
+// src/main.tsx
+<BrowserRouter>
+  <CookieChimpReinit />
+  <App />
+</BrowserRouter>
+```
+
+### SvelteKit
+
+Add the script to `src/app.html` inside `<head>`, then re-initialize on navigation from your root layout:
+
+```svelte
+<!-- src/routes/+layout.svelte -->
+<script>
+  import { afterNavigate } from "$app/navigation";
+
+  afterNavigate(() => {
+    if (typeof window !== "undefined") {
+      window.CookieChimp?.reinitialize?.();
+    }
+  });
+</script>
+
+<slot />
+```
+
+### Generic SPA (no router events)
+
+If your framework doesn't expose a router event you can hook into, listen for `history.pushState` and `popstate`:
+
+```html
+<script>
+  function runCookieChimp() {
+    if (typeof window.CookieChimp?.reinitialize === "function") {
+      window.CookieChimp.reinitialize();
+    } else if (!document.getElementById("cookiechimp-js")) {
+      var script = document.createElement("script");
+      script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
+      script.id = "cookiechimp-js";
+      document.head.appendChild(script);
+    }
+  }
+
+  // Patch pushState/replaceState so we get notified on client-side navigation.
+  ["pushState", "replaceState"].forEach((method) => {
+    var original = history[method];
+    history[method] = function () {
+      var result = original.apply(this, arguments);
+      window.dispatchEvent(new Event("locationchange"));
+      return result;
+    };
+  });
+  window.addEventListener("popstate", () => window.dispatchEvent(new Event("locationchange")));
+  window.addEventListener("locationchange", runCookieChimp);
+
+  // First load.
+  runCookieChimp();
+</script>
+```
+
+---
+
 ## How do I position the Privacy Trigger in an SPA?
 
-You can specify location where the Privacy Trigger (floating icon to update preferences) is added to the DOM by placing a div with the ID `cookiechimp-container` on the page.
+The Privacy Trigger is the floating icon users click to update their consent preferences. By default it's appended to `<body>`, which is fine for traditional pages — but in an SPA, you usually want it in a **specific spot in your layout** and you want it to **survive route changes**.
+
+Place a `<div>` with the ID `cookiechimp-container` wherever you want the trigger rendered:
 
 ```html
 <div id="cookiechimp-container"></div>
 ```
 
-This is useful for single page applications (SPA) where you want the floating icon to be persistent across different pages.
-Ensure to add this in a location which does not get replaced when navigating between pages.
+Put this in a part of your layout that **doesn't unmount on navigation** — typically the root layout, just inside `<body>`.
 
-If you are using [Turbo](https://turbo.hotwired.dev/handbook/building#persisting-elements-across-page-loads) or [Astro JS with View Transitions](https://docs.astro.build/en/guides/view-transitions/), you can add specific attributes to the div to ensure it persists across navigations.
+### Persisting across view transitions
+
+Some frameworks tear down and recreate DOM nodes between routes, which would remove the Privacy Trigger. Use the framework's "persistent element" attribute to keep it:
 
 ```html
-<!-- For Turbo -->
-<div id="cookiechimp-container" data-turbo-permanent></div>
-
-<!-- For Astro JS -->
+<!-- Astro (View Transitions) -->
 <div id="cookiechimp-container" transition:persist></div>
+
+<!-- Hotwire Turbo -->
+<div id="cookiechimp-container" data-turbo-permanent></div>
 ```
+
+See the Astro docs on [persisting components](https://docs.astro.build/en/guides/view-transitions/#maintaining-state) and the Turbo docs on [persisting elements across page loads](https://turbo.hotwired.dev/handbook/building#persisting-elements-across-page-loads).
+
+---
 
 ## How do I run code based on consent?
 
-The `cc:onConsented` event can be used to execute code based on user consent.
+The `cc:onConsented` event fires once when the user has made an initial choice (and on subsequent page loads when consent is already stored).
 
 ```javascript
 window.addEventListener("cc:onConsented", function (event) {
@@ -60,7 +212,7 @@ window.addEventListener("cc:onConsented", function (event) {
 });
 ```
 
-The `cc:onUpdate` event can be used to execute code when the user changes their consent.
+The `cc:onUpdate` event fires when the user changes their consent from the preferences modal.
 
 ```javascript
 window.addEventListener("cc:onUpdate", function (event) {
@@ -90,4 +242,12 @@ window.addEventListener("cc:onUpdate", function (event) {
 });
 ```
 
-<Info>[View all available callbacks & events ›](/callback-events)</Info>
+<Snippet file="install/callbacks-events-link.mdx" />
+
+---
+
+## Troubleshooting
+
+- **Banner shows on first load but not after navigation** — your re-initialization listener isn't firing. Double-check the framework-specific event name (`astro:page-load`, `router.afterEach`, `useLocation`, `afterNavigate`).
+- **Privacy Trigger disappears after navigation** — add the framework's persistence attribute (`transition:persist`, `data-turbo-permanent`) to your `#cookiechimp-container` div.
+<Snippet file="install/spa-troubleshooting-base.mdx" />

--- a/installation/single-page-applications.mdx
+++ b/installation/single-page-applications.mdx
@@ -34,17 +34,18 @@ The pattern is the same across all SPA frameworks:
 
 The exact navigation event differs per framework. Pick yours below.
 
+The reinit pattern is the same across frameworks: **remove the existing CookieChimp script tag (if any) and append a fresh one**. Loading the script again triggers CookieChimp to rescan the newly mounted DOM. There's no public `reinitialize()` API — script re-injection is the documented mechanism.
+
 ### Astro
 
-Astro's [View Transitions](https://docs.astro.build/en/guides/view-transitions/) emit an `astro:page-load` event after every navigation (including the first). Use `is:inline` so Astro doesn't bundle the script.
+Astro's [View Transitions](https://docs.astro.build/en/guides/view-transitions/) emit an `astro:page-load` event after every navigation **including the first**, so this single handler covers both initial load and subsequent transitions — no separate static `<script src>` needed. Use `is:inline` so Astro doesn't bundle the script.
 
 Add this to your root layout — typically `src/layouts/Layout.astro` — inside `<head>`:
 
 ```html
 <script is:inline>
   function runCookieChimp() {
-    // Don't re-inject if the script is already on the page.
-    if (document.getElementById("cookiechimp-js")) return;
+    document.getElementById("cookiechimp-js")?.remove();
 
     var script = document.createElement("script");
     script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
@@ -65,7 +66,7 @@ Add this to your root layout — typically `src/layouts/Layout.astro` — inside
 
 ### Vue (Vue Router)
 
-Add the script tag in your `index.html` `<head>` and re-initialize on every route change from your router config (`src/router/index.js`):
+Add the script tag in your `index.html` `<head>` for the initial load, then re-inject on every subsequent route change from your router config (`src/router/index.js`):
 
 ```js
 import { createRouter, createWebHistory } from "vue-router";
@@ -75,10 +76,19 @@ const router = createRouter({
   routes: [/* ... */],
 });
 
+let isInitial = true;
 router.afterEach(() => {
-  if (typeof window.CookieChimp?.reinitialize === "function") {
-    window.CookieChimp.reinitialize();
+  if (isInitial) {
+    isInitial = false;
+    return;
   }
+
+  document.getElementById("cookiechimp-js")?.remove();
+
+  const script = document.createElement("script");
+  script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
+  script.id = "cookiechimp-js";
+  document.head.appendChild(script);
 });
 
 export default router;
@@ -86,19 +96,29 @@ export default router;
 
 ### React (React Router v6+)
 
-Add the script tag in your `index.html` `<head>`, then create a tiny component that listens to location changes and mount it once at the top of your tree:
+Add the script tag in your `index.html` `<head>` for the initial load, then mount a tiny component that re-injects on subsequent route changes:
 
 ```tsx
 // src/components/CookieChimpReinit.tsx
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
 
 export default function CookieChimpReinit() {
   const { pathname } = useLocation();
+  const isFirstRender = useRef(true);
 
   useEffect(() => {
-    // @ts-ignore
-    window.CookieChimp?.reinitialize?.();
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    document.getElementById("cookiechimp-js")?.remove();
+
+    const script = document.createElement("script");
+    script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
+    script.id = "cookiechimp-js";
+    document.head.appendChild(script);
   }, [pathname]);
 
   return null;
@@ -115,17 +135,29 @@ export default function CookieChimpReinit() {
 
 ### SvelteKit
 
-Add the script to `src/app.html` inside `<head>`, then re-initialize on navigation from your root layout:
+Add the script to `src/app.html` inside `<head>` for the initial load, then re-inject on subsequent navigations from your root layout:
 
 ```svelte
 <!-- src/routes/+layout.svelte -->
 <script>
   import { afterNavigate } from "$app/navigation";
+  import { browser } from "$app/environment";
+
+  let isInitial = true;
 
   afterNavigate(() => {
-    if (typeof window !== "undefined") {
-      window.CookieChimp?.reinitialize?.();
+    if (!browser) return;
+    if (isInitial) {
+      isInitial = false;
+      return;
     }
+
+    document.getElementById("cookiechimp-js")?.remove();
+
+    const script = document.createElement("script");
+    script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
+    script.id = "cookiechimp-js";
+    document.head.appendChild(script);
   });
 </script>
 
@@ -134,19 +166,17 @@ Add the script to `src/app.html` inside `<head>`, then re-initialize on navigati
 
 ### Generic SPA (no router events)
 
-If your framework doesn't expose a router event you can hook into, listen for `history.pushState` and `popstate`:
+If your framework doesn't expose a router event you can hook into, listen for `history.pushState` and `popstate` — this fires on both programmatic navigation and back/forward:
 
 ```html
 <script>
   function runCookieChimp() {
-    if (typeof window.CookieChimp?.reinitialize === "function") {
-      window.CookieChimp.reinitialize();
-    } else if (!document.getElementById("cookiechimp-js")) {
-      var script = document.createElement("script");
-      script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
-      script.id = "cookiechimp-js";
-      document.head.appendChild(script);
-    }
+    document.getElementById("cookiechimp-js")?.remove();
+
+    var script = document.createElement("script");
+    script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
+    script.id = "cookiechimp-js";
+    document.head.appendChild(script);
   }
 
   // Patch pushState/replaceState so we get notified on client-side navigation.

--- a/installation/squarespace.mdx
+++ b/installation/squarespace.mdx
@@ -1,0 +1,49 @@
+---
+title: "Squarespace"
+description: "Install a consent banner on your Squarespace site."
+icon: "squarespace"
+---
+
+<Steps>
+  <Step title="Copy your CookieChimp snippet">
+    <Snippet file="install/cms-copy-snippet-step.mdx" />
+  </Step>
+
+  <Step title="Add the snippet via Code Injection">
+    1. Log into your Squarespace dashboard.
+    2. Navigate to **Website → Pages** in the main menu.
+    3. Expand the **Utilities** (or **Website Tools**) section and select **Code Injection**.
+    4. Paste the CookieChimp snippet into the **Header** section. This ensures the script loads in the `<head>` of every page.
+    5. Click **Save** at the top of the page.
+
+    <Snippet file="install/script-first-warning.mdx" />
+  </Step>
+
+  <Step title="Disable Squarespace's built-in cookie banner">
+    Squarespace has a built-in cookie banner that will conflict with CookieChimp. Turn it off:
+
+    1. Go to **Settings → Cookies & Visitor Data**.
+    2. Disable the Squarespace **Cookie Banner**.
+
+    You'll now use CookieChimp as your single source of consent.
+  </Step>
+
+  <Step title="Block scripts & cookies">
+    <Snippet file="install/cms-block-scripts-step.mdx" />
+
+    <Tip>
+      Common third-party tools on Squarespace include Google Analytics, Facebook Pixel, and chat widgets — these typically belong to the `analytics` or `marketing` categories. If you add them via Code Injection or Code blocks, update them to use `type="text/plain"` and a `data-category` attribute.
+    </Tip>
+  </Step>
+
+  <Step title="Allow users to update their preferences">
+    <Snippet file="install/cms-preferences-step.mdx" />
+  </Step>
+</Steps>
+
+## Troubleshooting
+
+- Make sure your Squarespace domain (including any custom domain you've connected) is allowed in the **Account Settings** in your CookieChimp dashboard.
+- Some Squarespace plans (notably the Personal plan) do not support Code Injection. You'll need the Business plan or higher to use CookieChimp.
+- Code Injection is **only applied on the live site** — it will not run inside the Squarespace editor preview.
+<Snippet file="install/cms-troubleshooting-footer.mdx" />

--- a/installation/sveltekit.mdx
+++ b/installation/sveltekit.mdx
@@ -1,0 +1,112 @@
+---
+title: "SvelteKit"
+description: "Install a consent banner in a SvelteKit application."
+icon: "code"
+---
+
+SvelteKit uses client-side navigation by default. CookieChimp installs in `app.html` and reinitializes on every navigation via the `afterNavigate` lifecycle hook.
+
+<Snippet file="install/account-id-prerequisites.mdx" />
+
+---
+
+## How do I load the CookieChimp script?
+
+Add the script tag to `src/app.html` inside `<head>`, before `%sveltekit.head%` and any other tags so it loads first:
+
+```html
+<!-- src/app.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js"></script>
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>
+```
+
+<Snippet file="install/replace-account-id.mdx" />
+
+---
+
+## How do I handle client-side navigation?
+
+SvelteKit transitions between pages without a full reload. Use `afterNavigate` in your root layout to reinitialize the CookieChimp widget on every navigation:
+
+```svelte
+<!-- src/routes/+layout.svelte -->
+<script lang="ts">
+  import { afterNavigate } from "$app/navigation";
+  import { browser } from "$app/environment";
+
+  afterNavigate(() => {
+    if (browser) {
+      // @ts-ignore
+      window.CookieChimp?.reinitialize?.();
+    }
+  });
+</script>
+
+<div id="cookiechimp-container"></div>
+
+<slot />
+```
+
+<Info>
+  The `browser` check guards against SSR — `window.CookieChimp` doesn't exist on the server.
+</Info>
+
+---
+
+## How do I check consent status in code?
+
+Wrap the CookieChimp events in a Svelte store so any component can subscribe:
+
+```ts
+// src/lib/stores/consent.ts
+import { writable } from "svelte/store";
+import { browser } from "$app/environment";
+
+export const consent = writable<Record<string, boolean>>({});
+
+if (browser) {
+  function update() {
+    consent.set({
+      // @ts-ignore
+      analytics: !!window.CookieConsent?.acceptedService?.("Google Analytics", "analytics"),
+    });
+  }
+
+  update();
+  window.addEventListener("cc:onConsented", update);
+  window.addEventListener("cc:onUpdate", update);
+}
+```
+
+Use it in a component:
+
+```svelte
+<script lang="ts">
+  import { consent } from "$lib/stores/consent";
+</script>
+
+{#if $consent.analytics}
+  <p>Analytics is enabled.</p>
+{/if}
+```
+
+<Snippet file="install/service-category-note.mdx" />
+
+<Snippet file="install/callbacks-events-link.mdx" />
+
+---
+
+## Troubleshooting
+
+- **Banner shows on first load but not after navigation** — make sure `afterNavigate` is called from your **root** `+layout.svelte`, not from a nested layout.
+- **`window is not defined` errors** — wrap any `window.CookieChimp` access in a `browser` check from `$app/environment`.
+<Snippet file="install/spa-troubleshooting-base.mdx" />

--- a/installation/sveltekit.mdx
+++ b/installation/sveltekit.mdx
@@ -35,7 +35,7 @@ Add the script tag to `src/app.html` inside `<head>`, before `%sveltekit.head%` 
 
 ## How do I handle client-side navigation?
 
-SvelteKit transitions between pages without a full reload. Use `afterNavigate` in your root layout to reinitialize the CookieChimp widget on every navigation:
+SvelteKit transitions between pages without a full reload. Use `afterNavigate` in your root layout to re-inject the CookieChimp script on every navigation — this triggers a rescan of the newly mounted route's DOM. The static `<script>` tag in `app.html` handles the first page load, so we skip the initial `afterNavigate` call.
 
 ```svelte
 <!-- src/routes/+layout.svelte -->
@@ -43,11 +43,21 @@ SvelteKit transitions between pages without a full reload. Use `afterNavigate` i
   import { afterNavigate } from "$app/navigation";
   import { browser } from "$app/environment";
 
+  let isInitial = true;
+
   afterNavigate(() => {
-    if (browser) {
-      // @ts-ignore
-      window.CookieChimp?.reinitialize?.();
+    if (!browser) return;
+    if (isInitial) {
+      isInitial = false;
+      return;
     }
+
+    document.getElementById("cookiechimp-js")?.remove();
+
+    const script = document.createElement("script");
+    script.src = "https://cookiechimp.com/widget/YOUR_ACCOUNT_ID.js";
+    script.id = "cookiechimp-js";
+    document.head.appendChild(script);
   });
 </script>
 
@@ -57,7 +67,7 @@ SvelteKit transitions between pages without a full reload. Use `afterNavigate` i
 ```
 
 <Info>
-  The `browser` check guards against SSR — `window.CookieChimp` doesn't exist on the server.
+  The `browser` check guards against SSR — `document` and `window` don't exist on the server, so any DOM access must be wrapped.
 </Info>
 
 ---
@@ -108,5 +118,5 @@ Use it in a component:
 ## Troubleshooting
 
 - **Banner shows on first load but not after navigation** — make sure `afterNavigate` is called from your **root** `+layout.svelte`, not from a nested layout.
-- **`window is not defined` errors** — wrap any `window.CookieChimp` access in a `browser` check from `$app/environment`.
+- **`window is not defined` / `document is not defined` errors** — wrap any DOM or `window` access in a `browser` check from `$app/environment`.
 <Snippet file="install/spa-troubleshooting-base.mdx" />

--- a/installation/webflow.mdx
+++ b/installation/webflow.mdx
@@ -1,0 +1,40 @@
+---
+title: "Webflow"
+description: "Install a consent banner on your Webflow site."
+icon: "webflow"
+---
+
+<Steps>
+  <Step title="Copy your CookieChimp snippet">
+    <Snippet file="install/cms-copy-snippet-step.mdx" />
+  </Step>
+
+  <Step title="Add the snippet to your Webflow project">
+    1. Log into your [Webflow dashboard](https://webflow.com/dashboard).
+    2. Select your project to open the **Designer**.
+    3. Navigate to **Project Settings** (gear icon at the bottom-left).
+    4. Open the **Custom Code** tab at the top.
+    5. In the **Head Code** section, paste the CookieChimp snippet.
+    6. Save the changes and click **Publish** at the top right of the Designer.
+
+    <Snippet file="install/script-first-warning.mdx" />
+  </Step>
+
+  <Step title="Block scripts & cookies">
+    <Snippet file="install/cms-block-scripts-step.mdx" />
+
+    <Tip>
+      If you embed third-party tools through Webflow's **Embed** elements (e.g. Hotjar, Intercom, custom pixels), update those embeds to use `type="text/plain"` and a `data-category` attribute so CookieChimp can manage them based on consent.
+    </Tip>
+  </Step>
+
+  <Step title="Allow users to update their preferences">
+    <Snippet file="install/cms-preferences-step.mdx" />
+  </Step>
+</Steps>
+
+## Troubleshooting
+
+- Make sure your **published** Webflow domain is allowed in the **Account Settings** in your CookieChimp dashboard. The `*.webflow.io` staging domain is not included by default — add it if you want to test the banner before publishing to a custom domain.
+- After saving custom code, you must **publish** the site again — changes do not appear on the staging or production URL until publish.
+<Snippet file="install/cms-troubleshooting-footer.mdx" />

--- a/installation/wix.mdx
+++ b/installation/wix.mdx
@@ -1,0 +1,66 @@
+---
+title: "Wix"
+description: "Install a consent banner on your Wix site."
+icon: "globe"
+---
+
+Wix lets you inject custom code into the `<head>` of every page from the site dashboard. CookieChimp drops in as a single script.
+
+<Info>
+  Custom code injection is available on **Wix Premium** plans. Free Wix sites cannot install third-party scripts.
+</Info>
+
+---
+
+<Steps>
+  <Step title="Copy your CookieChimp snippet">
+    <Snippet file="install/cms-copy-snippet-step.mdx" />
+  </Step>
+
+  <Step title="Add the snippet to your Wix site">
+    1. In your Wix dashboard, go to **Settings → Custom Code** (under the "Advanced" section).
+    2. Click **+ Add Custom Code**.
+    3. Paste the CookieChimp snippet into the code field.
+    4. Under **Add Code to Pages**, choose **All pages** and check **Load code once**.
+    5. Under **Place Code in**, select **Head**.
+    6. Give it a name (e.g. "CookieChimp") and click **Apply**.
+
+    <Warning>
+      Wix Custom Code only runs on your **published** site — not in the Wix Editor preview. Publish your site to test the banner.
+    </Warning>
+  </Step>
+
+  <Step title="Disable Wix's built-in cookie banner">
+    Wix shows its own consent banner by default, which will conflict with CookieChimp:
+
+    1. Go to **Settings → Cookies & Privacy** (or **Settings → Privacy** depending on your dashboard version).
+    2. Turn off the Wix **Cookie Consent Banner**.
+
+    CookieChimp now handles consent end-to-end.
+  </Step>
+
+  <Step title="Block scripts & cookies">
+    Wix injects several first-party scripts (Wix Analytics, chat widgets, marketing tools) that fall under analytics/marketing categories. Some of these are managed through Wix's own settings — disable them in **Settings → Marketing & SEO** if you want CookieChimp to be the sole consent gate.
+
+    For any third-party scripts you've added through Custom Code, use the standard CookieChimp blocking attributes — see our [Scripts Management Section](/block-scripts-cookies/script-attributes).
+  </Step>
+
+  <Step title="Allow users to update their preferences">
+    Enable the floating Privacy Trigger from CookieChimp's banner settings.
+
+    To open the preferences modal from a custom Wix button, you'll need to add an HTML element (Wix's "Embed Code → Embed HTML") with:
+
+    ```html
+    <button type="button" data-cc="show-preferencesModal">
+      Manage cookie preferences
+    </button>
+    ```
+  </Step>
+</Steps>
+
+## Troubleshooting
+
+- **Banner doesn't appear** — make sure your **published** Wix domain (not the `*.wixsite.com` editor URL) is allowed in your CookieChimp dashboard under **Account Settings → Additional Domains**.
+- **Custom Code option is missing** — you're on a Free Wix plan. Upgrade to a Premium plan to enable custom code injection.
+- **Wix banner still shows** — double-check that the Wix Cookie Consent Banner is disabled in **Settings → Cookies & Privacy**.
+<Snippet file="install/cms-troubleshooting-footer.mdx" />


### PR DESCRIPTION
## Summary

- Adds dedicated installation guides for the most-requested stacks that were previously missing or only briefly mentioned: **React (Vite + CRA)**, **Remix**, **Nuxt**, **Angular**, **Astro**, **SvelteKit**, **Webflow**, **Squarespace**, and **Wix**.
- Reworks the **JS & Single Page Apps** catch-all to cover Astro, Vue, React Router, SvelteKit, and a generic `pushState` fallback — now properly explains *why* SPAs need re-initialization and links out to the dedicated framework guides.
- Updates **Google Tag Manager** to document the "Via GTM" install method using the `Consent Initialization - All Pages` trigger (matching what the main app's install screen now teaches), alongside the existing Direct HTML approach.
- Expands **Shopify** with steps for disabling the built-in Customer Privacy banner, configuring `checkout.liquid` on Shopify Plus, and adding the preferences trigger from the footer menu.
- Extracts shared boilerplate into reusable partials under `_snippets/install/` following the existing `<Snippet file="...">` convention used by `_snippets/beta-access.mdx` — keeps prerequisites blocks, `YOUR_ACCOUNT_ID` warnings, service/category notes, SPA & CMS troubleshooting, preferences steps, etc. DRY across 13 pages.
- Updates `docs.json` navigation, `llms.txt`, and the main `installation.mdx` landing page with CardGroups for JS frameworks vs. CMS/hosted platforms.

## What's new

**New framework pages**
- `installation/react.mdx` — covers both Vite and Create React App, plus React Router v6+ reinit
- `installation/remix.mdx` — `app/root.tsx` install with `suppressHydrationWarning` and `useLocation` reinit
- `installation/nuxt.mdx` — `nuxt.config.ts` install with `tagPriority: "critical"` and a `.client.ts` router plugin
- `installation/angular.mdx` — `NavigationEnd` subscription pattern and `NgZone`-aware consent service
- `installation/astro.mdx` — two-path guide for standard install and View Transitions (`ClientRouter` / `astro:page-load` / `transition:persist`)
- `installation/sveltekit.mdx` — `app.html` install with `afterNavigate` and a `browser`-guarded Svelte store

**New CMS pages**
- `installation/webflow.mdx` — Custom Code in Project Settings, with notes for `*.webflow.io` staging
- `installation/squarespace.mdx` — Code Injection + disabling the built-in cookie banner
- `installation/wix.mdx` — Custom Code on Wix Premium plans + disabling the Wix banner

**New shared partials in `_snippets/install/`**
`account-id-prerequisites.mdx`, `replace-account-id.mdx`, `service-category-note.mdx`, `callbacks-events-link.mdx`, `spa-troubleshooting-base.mdx`, `script-first-warning.mdx`, `cms-copy-snippet-step.mdx`, `cms-block-scripts-step.mdx`, `cms-preferences-step.mdx`, `cms-troubleshooting-footer.mdx`.

## Test plan

- [ ] Mintlify build succeeds on preview (no broken `<Snippet>` references).
- [ ] Navigation in the Documentation dropdown shows all 14 install pages under "Platform Specific Installation".
- [ ] Spot-check that each new framework page renders the prerequisites Info box, the `Replace YOUR_ACCOUNT_ID` warning, the service/category note, and the troubleshooting block correctly (they all come from snippets now).
- [ ] Spot-check the CMS pages (Shopify, Webflow, Squarespace, Wix) for the shared step bodies and troubleshooting footer.
- [ ] Verify the updated GTM page renders both tabs (Direct HTML and Via GTM).
- [ ] Verify `installation/installation.mdx` CardGroups link correctly to all platform pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)