### PR TITLE
Add Integrations section to docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -68,6 +68,19 @@
             ]
           },
           {
+            "group": "Integrations",
+            "pages": [
+              "integrations/overview",
+              "integrations/global-privacy-control",
+              "integrations/google-consent-mode",
+              "integrations/meta-consent-api",
+              "integrations/microsoft-clarity",
+              "integrations/microsoft-uet",
+              "integrations/shopify-privacy-api",
+              "integrations/wordpress-consent-api"
+            ]
+          },
+          {
             "group": "Advanced",
             "pages": [
               "features/block-iframes",

--- a/integrations/global-privacy-control.mdx
+++ b/integrations/global-privacy-control.mdx
@@ -1,0 +1,39 @@
+---
+title: "Global Privacy Control"
+description: "Automatically honor the GPC browser signal so opt-out users skip the banner."
+icon: "shield-check"
+---
+
+Global Privacy Control (GPC) is a browser signal that lets a visitor opt out of the sale or sharing of their personal data without interacting with a consent banner. Some privacy laws — most notably California's CCPA/CPRA — require sites to honor this signal.
+
+When the GPC integration is enabled, CookieChimp detects the signal and records the visitor's opt-out preferences automatically. The banner is not shown.
+
+Based on the setup you have done to not track or run scripts when consent is denied, that behaviour will be in place automatically for these visitors.
+
+## How do I enable it?
+
+<Steps>
+  <Step title="Open the Integrations page">
+    Go to **Integrations** in your CookieChimp dashboard and find the Global Privacy Control card.
+    <img src="/images/faq/gpc.png" alt="Enable Global Privacy Control" />
+  </Step>
+
+  <Step title="Toggle it on">
+    Turn the integration on. No further configuration is required.
+  </Step>
+</Steps>
+
+## Which browsers send GPC?
+
+- DuckDuckGo browser
+- Brave (with the GPC setting enabled)
+- Firefox (via extensions such as Privacy Badger)
+- Chrome, Edge, and Safari (via GPC extensions)
+
+## How do I verify it's working?
+
+1. Enable **Debug mode** from **Settings → Consent Features** in your dashboard.
+2. Visit your site from a browser that sends GPC (e.g. DuckDuckGo or Brave with GPC on).
+3. The banner should not appear, and the browser console will log that opt-out preferences were applied automatically.
+
+<Snippet file="install/cms-troubleshooting-footer.mdx" />

--- a/integrations/google-consent-mode.mdx
+++ b/integrations/google-consent-mode.mdx
@@ -1,0 +1,39 @@
+---
+title: "Google Consent Mode"
+description: "Send consent state to Google's tags for Analytics, Ads, and other Google services."
+icon: "google"
+---
+
+Google Consent Mode lets Google's tags (Google Analytics 4, Google Ads, Floodlight, and others) adjust their behaviour based on the visitor's consent. When the integration is enabled, CookieChimp updates Google's consent state automatically as the user accepts or rejects categories and services.
+
+If you're using Google Tag Manager, follow our full [Google Tag Manager guide](/installation/google-tag-manager) — it covers Consent Mode plus how to gate individual tags on specific vendors.
+
+## How do I enable it?
+
+<Steps>
+  <Step title="Open the Integrations page">
+    Go to **Integrations** in your CookieChimp dashboard.
+    <img src="/images/google-tag-manager/enable-gcm.png" alt="Enable Google Consent Mode" />
+  </Step>
+
+  <Step title="Toggle Google Consent Mode on">
+    CookieChimp will start pushing consent state to the `dataLayer` using Google's `gtag('consent', ...)` API on page load and whenever the user updates their choices.
+  </Step>
+</Steps>
+
+## How does CookieChimp map to Google consent types?
+
+GTM supports 7 default consent types. CookieChimp maps them to your categories as follows:
+
+| CookieChimp Category ID | Google Consent Type                          |
+| ----------------------- | -------------------------------------------- |
+| essential               | functionality_storage, security_storage      |
+| marketing               | ad_storage, ad_user_data, ad_personalization |
+| analytics               | analytics_storage                            |
+| personalization         | personalization_storage                      |
+
+When a user opts in to a category — or to a specific Google service in that category — the linked Google consent type flips from `denied` to `granted` (and vice versa).
+
+CookieChimp also pushes the consent state of individual services. For example, granting consent to a service named **"Google Analytics"** sets that vendor's state to `granted`, which lets you gate a tag on the specific vendor rather than the whole category. See the [GTM guide](/installation/google-tag-manager#how-do-i-block-tags-with-google-tag-manager) for how to wire this into a tag.
+
+<Snippet file="install/cms-troubleshooting-footer.mdx" />

--- a/integrations/meta-consent-api.mdx
+++ b/integrations/meta-consent-api.mdx
@@ -1,0 +1,32 @@
+---
+title: "Meta Consent API"
+description: "Send consent state to the Meta (Facebook/Instagram) Pixel."
+icon: "facebook"
+---
+
+The Meta Consent API integration tells the Meta Pixel — used by Facebook and Instagram ads — whether the visitor has consented to advertising tracking. When the integration is enabled, CookieChimp calls `fbq('consent', 'grant')` or `fbq('consent', 'revoke')` automatically as the user's preferences change.
+
+## Prerequisites
+
+- A Meta Pixel installed on your site.
+- A category or service in CookieChimp that represents Meta advertising consent (most accounts map this to the **marketing** category or a **Facebook Pixel** vendor).
+
+## How do I enable it?
+
+<Steps>
+  <Step title="Open the Integrations page">
+    Go to **Integrations** in your CookieChimp dashboard and find the Meta Consent API card.
+  </Step>
+
+  <Step title="Toggle it on">
+    CookieChimp will push consent state to the Meta Pixel on page load and whenever the visitor updates their choices.
+  </Step>
+</Steps>
+
+## How do I verify it's working?
+
+1. Install Meta's [Pixel Helper](https://www.facebook.com/business/help/198406697184603) browser extension.
+2. Open your site and decline marketing consent. Pixel Helper should show the pixel in a **consent revoked** state and no events should fire.
+3. Accept marketing consent and reload. The pixel should now report as **active** and events should fire normally.
+
+<Snippet file="install/cms-troubleshooting-footer.mdx" />

--- a/integrations/microsoft-clarity.mdx
+++ b/integrations/microsoft-clarity.mdx
@@ -1,0 +1,33 @@
+---
+title: "Microsoft Clarity Consent Mode"
+description: "Allow or block Microsoft Clarity session recordings and heatmaps based on consent."
+icon: "chart-bar"
+---
+
+Microsoft Clarity is a free product-analytics tool that captures session recordings and heatmaps. With Consent Mode enabled, Clarity only collects data once the visitor has consented to analytics tracking.
+
+When the integration is enabled, CookieChimp calls Clarity's consent API (`clarity('consent')`) automatically as the user's preferences change.
+
+## Prerequisites
+
+- A Microsoft Clarity project with its tracking snippet installed on your site.
+- A category or service in CookieChimp that represents analytics consent (most accounts map this to the **analytics** category or a **Microsoft Clarity** vendor).
+
+## How do I enable it?
+
+<Steps>
+  <Step title="Open the Integrations page">
+    Go to **Integrations** in your CookieChimp dashboard and find the Microsoft Clarity Consent Mode card.
+  </Step>
+
+  <Step title="Toggle it on">
+    CookieChimp will push consent state to Clarity on page load and whenever the visitor updates their choices.
+  </Step>
+</Steps>
+
+## How do I verify it's working?
+
+1. Open your site in a private window and **decline** analytics consent. No session recordings should appear in your Clarity dashboard.
+2. Reload, **accept** analytics, and browse your site. After a few minutes a new session should show up in Clarity.
+
+<Snippet file="install/cms-troubleshooting-footer.mdx" />

--- a/integrations/microsoft-uet.mdx
+++ b/integrations/microsoft-uet.mdx
@@ -1,0 +1,34 @@
+---
+title: "Microsoft UET Consent Mode"
+description: "Pass consent to Microsoft's Universal Event Tracking tag for Microsoft Advertising."
+icon: "target"
+---
+
+Microsoft Universal Event Tracking (UET) is the tag used by Microsoft Advertising for conversion tracking and remarketing audiences. With UET Consent Mode, the tag adjusts what it tracks based on the visitor's consent.
+
+When the integration is enabled, CookieChimp calls UET's consent API (`uetq.push('consent', ...)`) automatically as the user's preferences change.
+
+## Prerequisites
+
+- A Microsoft Advertising account with a UET tag installed on your site.
+- A category or service in CookieChimp that represents advertising consent (most accounts map this to the **marketing** category or a **Microsoft Ads** vendor).
+
+## How do I enable it?
+
+<Steps>
+  <Step title="Open the Integrations page">
+    Go to **Integrations** in your CookieChimp dashboard and find the Microsoft UET Consent Mode card.
+  </Step>
+
+  <Step title="Toggle it on">
+    CookieChimp will push consent state to UET on page load and whenever the visitor updates their choices.
+  </Step>
+</Steps>
+
+## How do I verify it's working?
+
+1. Open your site with browser DevTools open on the **Network** tab and filter for `bat.bing.com`.
+2. Decline advertising consent — no requests to `bat.bing.com` should be sent (or they should be sent with `ad_storage=denied`).
+3. Accept advertising consent and reload — UET requests should now fire with consent granted.
+
+<Snippet file="install/cms-troubleshooting-footer.mdx" />

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -1,0 +1,41 @@
+---
+title: "Integrations Overview"
+description: "Connect CookieChimp with third-party services so they respect user consent."
+icon: "plug"
+---
+
+CookieChimp integrations forward consent signals to other tools — analytics, advertising pixels, ecommerce platforms, and CMS plugins — so each service automatically adjusts what it tracks based on the visitor's choices.
+
+Enable any integration from the **Integrations** page in your [CookieChimp dashboard](https://app.cookiechimp.com).
+
+## Available integrations
+
+<CardGroup cols={2}>
+  <Card title="Global Privacy Control" icon="shield-check" href="/integrations/global-privacy-control">
+    Automatically honor the GPC browser signal without showing the banner.
+  </Card>
+
+  <Card title="Google Consent Mode" icon="google" href="/integrations/google-consent-mode">
+    Update Google's consent state for Analytics, Ads, and other Google tags.
+  </Card>
+
+  <Card title="Meta Consent API" icon="facebook" href="/integrations/meta-consent-api">
+    Send consent state to the Meta (Facebook/Instagram) Pixel.
+  </Card>
+
+  <Card title="Microsoft Clarity" icon="chart-bar" href="/integrations/microsoft-clarity">
+    Stop or allow Clarity session recordings based on consent.
+  </Card>
+
+  <Card title="Microsoft UET" icon="target" href="/integrations/microsoft-uet">
+    Pass consent to Microsoft's Universal Event Tracking tag.
+  </Card>
+
+  <Card title="Shopify Customer Privacy API" icon="shopify" href="/integrations/shopify-privacy-api">
+    Sync consent with Shopify's storefront and first-party pixels.
+  </Card>
+
+  <Card title="WordPress Consent API" icon="wordpress" href="/integrations/wordpress-consent-api">
+    Share consent with any WordPress plugin that supports the WP Consent API.
+  </Card>
+</CardGroup>

--- a/integrations/shopify-privacy-api.mdx
+++ b/integrations/shopify-privacy-api.mdx
@@ -1,0 +1,40 @@
+---
+title: "Shopify Customer Privacy API"
+description: "Sync consent with Shopify's storefront so first-party pixels and Shop Pay respect the visitor's choices."
+icon: "shopify"
+---
+
+Shopify's [Customer Privacy API](https://shopify.dev/docs/api/customer-privacy) is the framework Shopify and its apps use to check whether a visitor has consented to tracking. When the integration is enabled, CookieChimp updates the API as the user's preferences change, so Shopify's analytics, Shop Pay tracking, and any privacy-aware Shopify apps adjust automatically.
+
+## Prerequisites
+
+- The CookieChimp snippet installed on your Shopify theme — see the [Shopify installation guide](/installation/shopify) if you haven't done this yet.
+- Shopify's built-in cookie banner disabled at **Settings → Customer privacy → Cookie banner** (it conflicts with CookieChimp).
+
+## How do I enable it?
+
+<Steps>
+  <Step title="Open the Integrations page">
+    Go to **Integrations** in your CookieChimp dashboard and find the Shopify Customer Privacy API card.
+  </Step>
+
+  <Step title="Toggle it on">
+    CookieChimp will start signalling consent to Shopify's Customer Privacy API on page load and whenever the visitor updates their choices.
+  </Step>
+</Steps>
+
+## How do I verify it's working?
+
+Open your storefront in a browser console and check Shopify's API directly:
+
+```javascript
+// After accepting marketing consent
+window.Shopify.customerPrivacy.userCanBeTracked();        // true
+window.Shopify.customerPrivacy.getTrackingConsent();      // "yes"
+
+// After declining marketing consent
+window.Shopify.customerPrivacy.userCanBeTracked();        // false
+window.Shopify.customerPrivacy.getTrackingConsent();      // "no"
+```
+
+<Snippet file="install/cms-troubleshooting-footer.mdx" />

--- a/integrations/wordpress-consent-api.mdx
+++ b/integrations/wordpress-consent-api.mdx
@@ -1,0 +1,47 @@
+---
+title: "WordPress Consent API"
+description: "Share consent with any WordPress plugin that supports the WP Consent API."
+icon: "wordpress"
+---
+
+The [WP Consent API](https://wordpress.org/plugins/wp-consent-api/) is a standard interface that WordPress plugins can read to find out whether a visitor has consented to a given category of tracking. When the integration is enabled, CookieChimp keeps the WP Consent API up to date as the user's preferences change, so compatible plugins (Google Site Kit, WooCommerce, MonsterInsights, and many others) can react automatically.
+
+## Prerequisites
+
+- The [CookieChimp WordPress plugin](https://github.com/IdentitySquare/CookieChimp-WP/archive/refs/heads/main.zip) installed and configured with your Account ID — see the [WordPress installation guide](/installation/wordpress).
+- The [WP Consent API plugin](https://wordpress.org/plugins/wp-consent-api/) installed and activated from the WordPress plugin directory.
+
+## How do I enable it?
+
+<Steps>
+  <Step title="Open the Integrations page">
+    Go to **Integrations** in your CookieChimp dashboard and find the WordPress Consent API card.
+    <img src="/images/wordpress/wordpress-integration.png" alt="Enable WordPress Integration" />
+  </Step>
+
+  <Step title="Toggle it on">
+    CookieChimp will start writing consent state to the WP Consent API on page load and whenever the visitor updates their choices. Plugins that listen to the API will pick this up automatically.
+  </Step>
+</Steps>
+
+## How does CookieChimp map to WP Consent types?
+
+| CookieChimp Category | WP Consent API Type |
+| -------------------- | ------------------- |
+| essential            | `functional`        |
+| analytics            | `statistics`        |
+| marketing            | `marketing`         |
+| personalization      | `preferences`       |
+
+## How do I verify it's working?
+
+In a PHP file or via the [Query Monitor](https://wordpress.org/plugins/query-monitor/) plugin, check the consent state directly:
+
+```php
+wp_has_consent( 'statistics' ); // true if analytics is accepted
+wp_has_consent( 'marketing' );  // true if marketing is accepted
+```
+
+Change your consent choices on the front end and refresh — the values returned by `wp_has_consent()` should update accordingly.
+
+<Snippet file="install/cms-troubleshooting-footer.mdx" />


### PR DESCRIPTION
## Summary

Adds an **Integrations** group to the Documentation dropdown with one page per integration available on the CookieChimp dashboard.

Pages added under `integrations/`:

- `overview` — landing page with a card grid linking to each integration
- `global-privacy-control` — GPC browser signal
- `google-consent-mode` — Google's `gtag('consent', ...)` API
- `meta-consent-api` — Meta/Facebook Pixel consent
- `microsoft-clarity` — Clarity session-recording consent mode
- `microsoft-uet` — Microsoft Advertising UET consent mode
- `shopify-privacy-api` — Shopify Customer Privacy API
- `wordpress-consent-api` — WP Consent API

Each page follows the same structure: what the integration does, prerequisites, how to enable it, and how to verify it's working.

## Context — replaces PR #39 (`copilot/fix-38`)

That branch added the same integrations but pre-dated the repo's recent restructure, so it isn't mergeable as-is:

- File paths used a `docs/` prefix that no longer exists (everything is flat under the repo root now).
- It didn't use the install snippets under `_snippets/install/`.
- Several review comments on PR #39 asked to drop verbose sections (Benefits, Compliance Considerations, Best Practices, Related Documentation, Technical Implementation, etc.).

This PR carries the still-useful content over in the current format: flat paths, install snippets where applicable (`cms-troubleshooting-footer`), and the leaner page structure used by `installation/shopify.mdx` and friends.

Per request, also added a **Google Consent Mode** page (already mentioned in the GTM install guide — this gives it a home in the Integrations section and surfaces the consent-type mapping there too).

Closes #38. PR #39 can be closed once this lands.

## Test plan

- [ ] Preview the docs site locally and confirm the new **Integrations** group appears in the Documentation dropdown between **Features** and **Advanced**.
- [ ] Verify each integration page renders without MDX errors.
- [ ] Confirm internal links resolve: GPC → faq image, GTM cross-links from Google Consent Mode, Shopify/WordPress cross-links to their installation guides.
- [ ] Confirm the `cms-troubleshooting-footer` snippet renders on each page.
- [ ] Close PR #39 after this is merged.

https://claude.ai/code/session_01PY5259qUrxJ2EzK3MzvWD5

---
_Generated by [Claude Code](https://claude.ai/code/session_01PY5259qUrxJ2EzK3MzvWD5)_