### PR TITLE
Update icon names in FAQ and CMP documentation

### DIFF
--- a/faq.mdx
+++ b/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: "FAQ"
 description: "Answers to common questions about consent banners and cookie management."
-icon: "message-circle-question"
+icon: "message-circle-question-mark"
 ---
 
 ## How do I verify if everything is working correctly?

--- a/why-use-a-cmp.mdx
+++ b/why-use-a-cmp.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Why Use a CMP?"
 description: "What a consent management platform handles for you — and why building one yourself is harder than it looks."
-icon: "circle-question"
+icon: "circle-question-mark"
 ---
 
 If you're weighing up whether to build consent management in-house or use a dedicated CMP, this page covers what's actually involved. A consent solution is more than a banner — it's an ongoing system that touches legal compliance, ad tracking, performance, and user experience across every market you operate in.


### PR DESCRIPTION
## Summary
Updated icon references in documentation files to use the correct icon names with the "-mark" suffix.

## Changes
- Updated `faq.mdx`: Changed icon from `message-circle-question` to `message-circle-question-mark`
- Updated `why-use-a-cmp.mdx`: Changed icon from `circle-question` to `circle-question-mark`

## Details
These changes correct the icon identifiers to match the actual available icon names in the icon library. The "-mark" suffix appears to be the correct naming convention for these question mark icons.

https://claude.ai/code/session_011hnm4HiPbqFnpPHgE6pyYM