### PR TITLE
Reorganize installation docs with framework and builder grouping

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -40,20 +40,35 @@
             "group": "Platform Specific Installation",
             "pages": [
               "installation/google-tag-manager",
-              "installation/nextjs",
-              "installation/react",
-              "installation/remix",
-              "installation/nuxt",
-              "installation/angular",
-              "installation/astro",
-              "installation/sveltekit",
-              "installation/single-page-applications",
-              "installation/shopify",
               "installation/wordpress",
-              "installation/webflow",
-              "installation/squarespace",
-              "installation/wix",
-              "installation/adobe-launch"
+              "installation/shopify",
+              {
+                "group": "JavaScript Frameworks",
+                "pages": [
+                  "installation/nextjs",
+                  "installation/react",
+                  "installation/nuxt",
+                  "installation/angular",
+                  "installation/astro",
+                  "installation/sveltekit",
+                  "installation/remix",
+                  "installation/single-page-applications"
+                ]
+              },
+              {
+                "group": "Website Builders",
+                "pages": [
+                  "installation/webflow",
+                  "installation/wix",
+                  "installation/squarespace"
+                ]
+              },
+              {
+                "group": "Other Tag Managers",
+                "pages": [
+                  "installation/adobe-launch"
+                ]
+              }
             ]
           },
           {

--- a/installation/adobe-launch.mdx
+++ b/installation/adobe-launch.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adobe Launch"
 description: "Set up a consent banner with Adobe Launch (Adobe Experience Platform Tags)."
-icon: "square-a"
+icon: "adobe"
 ---
 
 Add your website's CookieChimp JS snippet in the `<head>` tag of your HTML, **before** the Adobe Launch embed code.


### PR DESCRIPTION
## Summary
Restructured the installation documentation navigation to improve organization by grouping related platforms into logical categories.

## Key Changes
- **Reorganized Platform Specific Installation section** with new nested groupings:
  - Created "JavaScript Frameworks" group containing: Next.js, React, Nuxt, Angular, Astro, SvelteKit, Remix, and Single Page Applications
  - Created "Website Builders" group containing: Webflow, Wix, and Squarespace
  - Created "Other Tag Managers" group containing: Adobe Launch
  - Kept Google Tag Manager and WordPress/Shopify at the top level for prominence

- **Updated Adobe Launch documentation icon** from "square-a" to "adobe" for better visual representation

## Implementation Details
The changes improve documentation discoverability by grouping installation guides by platform type rather than listing them all at the same level. This makes it easier for users to find installation instructions for their specific technology stack.

https://claude.ai/code/session_01XrrDNDTuDbufxLa57EHXN7