### PR TITLE
Add iconType property to Adobe Launch documentation

### DIFF
--- a/installation/adobe-launch.mdx
+++ b/installation/adobe-launch.mdx
@@ -2,6 +2,7 @@
 title: "Adobe Launch"
 description: "Set up a consent banner with Adobe Launch (Adobe Experience Platform Tags)."
 icon: "adobe"
+iconType: "brands"
 ---
 
 Add your website's CookieChimp JS snippet in the `<head>` tag of your HTML, **before** the Adobe Launch embed code.


### PR DESCRIPTION
## Summary
Updated the Adobe Launch documentation frontmatter to include the `iconType` property set to "brands", which specifies the icon style to use for the Adobe icon.

## Changes
- Added `iconType: "brands"` to the frontmatter metadata in the Adobe Launch documentation file

## Details
This change ensures the Adobe icon is rendered using the "brands" icon type, which is likely part of a design system or icon library that supports multiple icon style variants. This improves the visual consistency and proper rendering of the Adobe Launch documentation page.

https://claude.ai/code/session_01M5dZY3xgxZVgRCrdWpVUYD