### PR TITLE
Reorganize installation docs: move Next.js and React to top level

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -42,11 +42,11 @@
               "installation/google-tag-manager",
               "installation/wordpress",
               "installation/shopify",
+              "installation/nextjs",
+              "installation/react",
               {
                 "group": "JavaScript Frameworks",
                 "pages": [
-                  "installation/nextjs",
-                  "installation/react",
                   "installation/nuxt",
                   "installation/angular",
                   "installation/astro",


### PR DESCRIPTION
## Summary
Reorganized the documentation structure in `docs.json` to promote Next.js and React installation guides to top-level entries, moving them out of the "JavaScript Frameworks" group.

## Changes
- Moved `installation/nextjs` and `installation/react` from the "JavaScript Frameworks" group to top-level installation pages
- These guides now appear alongside other primary installation methods (Google Tag Manager, WordPress, Shopify)
- The "JavaScript Frameworks" group now contains only Nuxt, Angular, and Astro

## Rationale
This change reflects the prominence of Next.js and React in the ecosystem by giving them equal visibility to other major installation methods, while keeping less commonly used frameworks grouped together.

https://claude.ai/code/session_01EqCu3YajrpSW7ErRtez7ut