### PR TITLE
Document visitor properties and geo-targeted customization

### DIFF
--- a/_snippets/visitor-properties.mdx
+++ b/_snippets/visitor-properties.mdx
@@ -8,10 +8,10 @@ CookieChimp.visitorCountry; // 'GB'
 
 ### `CookieChimp.visitorRegion`
 
-The region/subdivision code of the visitor (e.g. `"ENG"` for England, `"CA"` for California). Useful when compliance rules differ by region within a country — for example, US state privacy laws.
+The region/subdivision code of the visitor (e.g. `"NY"` for New York, `"CA"` for California). Useful when compliance rules differ by region within a country — for example, US state privacy laws.
 
 ```js
-CookieChimp.visitorRegion; // 'ENG'
+CookieChimp.visitorRegion; // 'NY'
 ```
 
 ### `CookieChimp.visitorNeedsConsent`

--- a/_snippets/visitor-properties.mdx
+++ b/_snippets/visitor-properties.mdx
@@ -1,9 +1,9 @@
 ### `CookieChimp.visitorCountry`
 
-The ISO 3166-1 alpha-2 country code of the visitor (e.g. `"GB"`, `"US"`, `"CN"`, `"DE"`).
+The ISO 3166-1 alpha-2 country code of the visitor (e.g. `"US"`, `"GB"`, `"CN"`, `"DE"`).
 
 ```js
-CookieChimp.visitorCountry; // 'GB'
+CookieChimp.visitorCountry; // 'US'
 ```
 
 ### `CookieChimp.visitorRegion`

--- a/_snippets/visitor-properties.mdx
+++ b/_snippets/visitor-properties.mdx
@@ -1,0 +1,42 @@
+### `CookieChimp.visitorCountry`
+
+The ISO 3166-1 alpha-2 country code of the visitor (e.g. `"GB"`, `"US"`, `"CN"`, `"DE"`).
+
+```js
+CookieChimp.visitorCountry; // 'GB'
+```
+
+### `CookieChimp.visitorRegion`
+
+The region/subdivision code of the visitor (e.g. `"ENG"` for England, `"CA"` for California). Useful when compliance rules differ by region within a country — for example, US state privacy laws.
+
+```js
+CookieChimp.visitorRegion; // 'ENG'
+```
+
+### `CookieChimp.visitorNeedsConsent`
+
+`true` if a consent banner was shown to the visitor (either an opt-in or opt-out banner), `false` if the visitor's location does not require one.
+
+```js
+CookieChimp.visitorNeedsConsent; // true
+```
+
+### `CookieChimp.getConfig()['mode']`
+
+Returns the consent mode that was applied to the visitor based on your geolocation rules:
+
+- `"opt-in"` — the visitor was shown an opt-in banner (e.g. EU/EEA visitors under GDPR).
+- `"opt-out"` — the visitor was shown an opt-out banner (e.g. US visitors under CCPA-style regulations).
+
+```js
+CookieChimp.getConfig().mode; // 'opt-in'
+```
+
+<Warning>
+  These properties are populated once the CookieChimp script has initialised.
+  If you read them before initialisation — for example, at the very top of the
+  page — they may be `undefined`. Read them inside a [callback or event
+  handler](/advanced/callbacks-events) such as `cc:onModalReady`,
+  `cc:onConsented`, or after a check for `window.CookieChimp`.
+</Warning>

--- a/advanced/banner-overrides.mdx
+++ b/advanced/banner-overrides.mdx
@@ -1,11 +1,17 @@
 ---
-title: "Geo-Targeted Customization"
-description: "Customize the banner and your tags per country, region, or consent mode without duplicating banners."
+title: "Advanced Banner Overrides"
+description: "Programmatically override the banner for advanced customization — geo-targeted tweaks, conditional UI changes, and custom tag-firing logic."
 ---
 
-CookieChimp serves a single banner that already adapts to the visitor's location based on your geolocation rules. Sometimes, though, you'll want to layer **additional** behaviour on top of that — for example, hiding a UI element only for visitors from one country, or firing your analytics tags differently for opt-in vs. opt-out regions.
+Most banner customization should happen in the CookieChimp dashboard. You can create **multiple banners** targeting different geolocation rules — country, US state, or other region — each with its own categories, translations, and consent mode (opt-in or opt-out). If you need a different legal text in California, a separate banner for visitors from Germany, or a translated version for visitors from Japan, that's all configured without writing code.
 
-You can do this by reading visitor and config properties directly from the `window.CookieChimp` object — no need to maintain a second banner.
+This page covers the cases that **go beyond** dashboard configuration: programmatic overrides where you reach into `window.CookieChimp` from your own JavaScript or CSS to tweak the banner that's already been served. Common reasons to do this include:
+
+- Hiding or showing a UI element on the banner for visitors from one country only.
+- Firing analytics or marketing tags differently based on the consent mode that was applied.
+- Branching custom site logic on the visitor's region (e.g. showing a "Do Not Sell" link for California visitors).
+
+Geo-targeted customization is the most common use case, so most examples below are geo-based — but the same pattern works for any condition you can read from `window.CookieChimp`.
 
 ## What properties are available?
 
@@ -98,16 +104,17 @@ window.addEventListener("cc:onModalReady", function () {
 });
 ```
 
-## When should I use these properties vs. multiple banners?
+## When should I override vs. configure another banner?
 
-Use these properties when:
-
-- The cookies, services, and banner text are the **same** across regions, but you need a small UI or tag-firing tweak per region.
-- You want to keep a **single source of truth** for banner content and avoid maintaining duplicates.
-
-Configure separate banners (via geolocation rules in the dashboard) when:
+Configure a **separate banner** in the dashboard (via geolocation rules) when:
 
 - The set of categories, services, or legal text genuinely differs between regions.
-- You need different default consent states (opt-in vs. opt-out) — this is already handled by CookieChimp's geolocation rules and surfaced via `getConfig().mode`.
+- You need different default consent states (opt-in vs. opt-out) — CookieChimp surfaces the applied mode via `getConfig().mode`.
+- You need a translated version of the banner for a specific country or region.
+
+Use a **programmatic override** (as shown above) when:
+
+- The cookies, services, and banner text are the **same** across regions, but you need a small UI tweak or different tag-firing behaviour for one segment.
+- You want to keep a **single source of truth** for banner content and avoid maintaining duplicates just to flip one CSS rule or push one event.
 
 <Snippet file="install/cms-troubleshooting-footer.mdx" />

--- a/advanced/banner-overrides.mdx
+++ b/advanced/banner-overrides.mdx
@@ -129,13 +129,12 @@ See [Custom CSS](/advanced/custom-css) for the full list of CSS variables you ca
 
 Configure a **separate banner** in the dashboard (via geolocation rules) when:
 
-- The set of categories, services, or legal text genuinely differs between regions.
-- You need different default consent states (opt-in vs. opt-out) — CookieChimp surfaces the applied mode via `getConfig().mode`.
-- You need a translated version of the banner for a specific country or region.
+- You want different banner text, design, or configuration for a region — each banner has its own copy, styling, and consent mode (opt-in or opt-out), with translations built in.
+- The applied consent mode needs to differ between regions — CookieChimp surfaces the applied mode via `getConfig().mode`.
 
 Use a **programmatic override** (as shown above) when:
 
-- The cookies, services, and banner text are the **same** across regions, but you need a small UI tweak or different tag-firing behaviour for one segment.
+- The banner content is the **same** across regions, but you need a small UI tweak, a per-domain colour change, or different tag-firing behaviour for one segment.
 - You want to keep a **single source of truth** for banner content and avoid maintaining duplicates just to flip one CSS rule or push one event.
 
 <Snippet file="install/cms-troubleshooting-footer.mdx" />

--- a/advanced/banner-overrides.mdx
+++ b/advanced/banner-overrides.mdx
@@ -5,13 +5,13 @@ description: "Programmatically override the banner for advanced customization �
 
 Most banner customization should happen in the CookieChimp dashboard. You can create **multiple banners** targeting different geolocation rules — country, US state, or other region — each with its own categories, translations, and consent mode (opt-in or opt-out). If you need a different legal text in California, a separate banner for visitors from Germany, or a translated version for visitors from Japan, that's all configured without writing code.
 
-This page covers the cases that **go beyond** dashboard configuration: programmatic overrides where you reach into `window.CookieChimp` from your own JavaScript or CSS to tweak the banner that's already been served. Common reasons to do this include:
+This page covers the cases that **go beyond** dashboard configuration: programmatic overrides where you reach into `window.CookieChimp` (or its CSS variables) from your own JavaScript or CSS to tweak the banner that's already been served. Common reasons to do this include:
 
 - Hiding or showing a UI element on the banner for visitors from one country only.
-- Firing analytics or marketing tags differently based on the consent mode that was applied.
-- Branching custom site logic on the visitor's region (e.g. showing a "Do Not Sell" link for California visitors).
+- Tagging your own analytics or CRM events with the consent mode that was applied, for internal reporting.
+- Giving the banner different branding on each of your domains while sharing a single CookieChimp account.
 
-Geo-targeted customization is the most common use case, so most examples below are geo-based — but the same pattern works for any condition you can read from `window.CookieChimp`.
+Geo-targeted customization is the most common reason to drop down to code, but the same pattern works for any condition you can read from `window.CookieChimp` or the current page.
 
 ## What properties are available?
 
@@ -77,26 +77,53 @@ window.addEventListener("cc:onModalReady", function () {
 
 Swap `window.analytics.identify` for whichever analytics or CDP SDK you use (Segment, Amplitude, Mixpanel, PostHog, etc.). Once these properties are attached to the visitor, every downstream event can be filtered or grouped by consent mode and region.
 
-## Example: show a "Do Not Sell" link for California visitors
+## Example: per-domain branding when sharing one account
 
-Some US state laws (like CCPA in California) require a "Do Not Sell My Personal Information" link in your site footer. You can render this link conditionally based on `visitorRegion`, so it only appears for visitors who actually need it:
+If you run multiple domains from a single CookieChimp account — for example, a brand and its regional subsidiaries — you can keep one set of categories, vendor lists, and consent records, while still giving each domain its own banner colours. The dashboard sets the global theme; a tiny CSS override on each domain swaps the variables that need to differ.
+
+Add the override directly in each site's stylesheet (or inject it from your tag manager):
+
+```css
+/* brand-a.com */
+#cc-main {
+  --cc-btn-primary-bg: #ff5a5f;
+  --cc-btn-primary-hover-bg: #e0484d;
+  --cc-link-color: #ff5a5f;
+}
+```
+
+```css
+/* brand-b.com */
+#cc-main {
+  --cc-btn-primary-bg: #2ec27e;
+  --cc-btn-primary-hover-bg: #26a868;
+  --cc-link-color: #2ec27e;
+}
+```
+
+If you'd rather have the variables live in one shared stylesheet and branch at runtime — for example, when you serve the same JS bundle across all domains — switch on `location.hostname`:
 
 ```js
-window.addEventListener("cc:onModalReady", function () {
-  if (
-    CookieChimp.visitorCountry === "US" &&
-    CookieChimp.visitorRegion === "CA"
-  ) {
-    document.getElementById("do-not-sell-link").style.display = "inline";
-  }
-});
+const themes = {
+  "brand-a.com": { primary: "#ff5a5f", hover: "#e0484d" },
+  "brand-b.com": { primary: "#2ec27e", hover: "#26a868" },
+};
+
+const theme = themes[location.hostname];
+if (theme) {
+  const style = document.createElement("style");
+  style.textContent = `
+    #cc-main {
+      --cc-btn-primary-bg: ${theme.primary};
+      --cc-btn-primary-hover-bg: ${theme.hover};
+      --cc-link-color: ${theme.primary};
+    }
+  `;
+  document.head.appendChild(style);
+}
 ```
 
-```html
-<a id="do-not-sell-link" href="#" style="display: none" data-cc="show-preferencesModal">
-  Do Not Sell My Personal Information
-</a>
-```
+See [Custom CSS](/advanced/custom-css) for the full list of CSS variables you can override.
 
 ## When should I override vs. configure another banner?
 

--- a/advanced/banner-overrides.mdx
+++ b/advanced/banner-overrides.mdx
@@ -57,41 +57,29 @@ window.addEventListener("cc:onModalReady", function () {
   Events](/advanced/callbacks-events) for other events you can hook into.
 </Tip>
 
-## Example: fire analytics in opt-out regions even without consent
+## Example: tag your own analytics with the visitor's consent mode
 
-If you've configured CookieChimp with **two consent modes** — opt-in for strict-consent countries (e.g. EU/EEA under GDPR) and opt-out for regions where pre-consent tracking is allowed (e.g. many US states) — you can use `getConfig().mode` to decide whether your analytics tag should fire before consent is granted.
+CookieChimp already handles tag-firing correctly for both opt-in and opt-out banners out of the box — opt-out banners fire analytics natively without waiting for consent, and Google Consent Mode is wired up automatically. You don't need to write code for that.
 
-In opt-out regions, you'll typically want tags to fire immediately (relying on Google Consent Mode to anonymise data until the user opts out). In opt-in regions, tags should only fire after the user grants consent for the relevant category.
-
-### Push a dataLayer event when the banner is in opt-out mode
+What you **may** want to do is segment your own product analytics by consent mode so you can build internal dashboards — for example, comparing engagement between visitors who saw an opt-in banner vs. an opt-out banner, or tracking consent rates by country for compliance reporting.
 
 ```js
-document.addEventListener("cc:onModalReady", function () {
-  if (window.CookieChimp.getConfig().mode === "opt-out") {
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push({ event: "cookiechimp_opt_out_mode" });
-  }
+window.addEventListener("cc:onModalReady", function () {
+  if (!window.analytics) return;
+
+  window.analytics.identify({
+    consent_mode: CookieChimp.getConfig().mode, // 'opt-in' or 'opt-out'
+    visitor_country: CookieChimp.visitorCountry,
+    visitor_region: CookieChimp.visitorRegion,
+  });
 });
 ```
 
-### Wire it into your tag firing condition
+Swap `window.analytics.identify` for whichever analytics or CDP SDK you use (Segment, Amplitude, Mixpanel, PostHog, etc.). Once these properties are attached to the visitor, every downstream event can be filtered or grouped by consent mode and region.
 
-In Google Tag Manager (or Adobe Launch), add the `cookiechimp_opt_out_mode` event as an **OR** condition on your analytics tag's trigger, alongside your existing category-consent condition:
+## Example: show a "Do Not Sell" link for California visitors
 
-1. Fire the tag **if** `CookieChimp.getConfig().mode === 'opt-out'` (the event above), **OR**
-2. Fire the tag **if** consent has been granted to the analytics category.
-
-This sends data immediately for visitors in opt-out regions while still respecting consent for visitors in opt-in regions. Because Google Consent Mode is already wired up by CookieChimp, no personal information is shared until the visitor explicitly opts in.
-
-<Warning>
-  For this to work reliably, the CookieChimp script must load **before** your
-  tag manager runs — not from inside GTM itself. See the [installation
-  guide](/installation/installation) for the recommended placement.
-</Warning>
-
-## Example: branch behaviour by US state
-
-`visitorRegion` lets you treat visitors from specific US states (or other subdivisions) differently. For example, you might want to log a custom event only for visitors from California:
+Some US state laws (like CCPA in California) require a "Do Not Sell My Personal Information" link in your site footer. You can render this link conditionally based on `visitorRegion`, so it only appears for visitors who actually need it:
 
 ```js
 window.addEventListener("cc:onModalReady", function () {
@@ -99,9 +87,15 @@ window.addEventListener("cc:onModalReady", function () {
     CookieChimp.visitorCountry === "US" &&
     CookieChimp.visitorRegion === "CA"
   ) {
-    // California-specific logic, e.g. show a "Do Not Sell" link
+    document.getElementById("do-not-sell-link").style.display = "inline";
   }
 });
+```
+
+```html
+<a id="do-not-sell-link" href="#" style="display: none" data-cc="show-preferencesModal">
+  Do Not Sell My Personal Information
+</a>
 ```
 
 ## When should I override vs. configure another banner?

--- a/advanced/callbacks-events.mdx
+++ b/advanced/callbacks-events.mdx
@@ -330,4 +330,4 @@ CookieChimp exposes properties on the `window.CookieChimp` object that tell you 
 
 <Snippet file="visitor-properties.mdx" />
 
-For full end-to-end examples — including hiding a button for visitors from a specific country and firing analytics tags in opt-out regions — see [Geo-Targeted Customization](/advanced/geo-targeted-customization).
+For full end-to-end examples — including hiding a button for visitors from a specific country and firing analytics tags in opt-out regions — see [Advanced Banner Overrides](/advanced/banner-overrides).

--- a/advanced/callbacks-events.mdx
+++ b/advanced/callbacks-events.mdx
@@ -323,3 +323,11 @@ CookieChimp.reset(true);
 // Reload the page
 window.location.reload();
 ```
+
+## What visitor & banner properties can I read?
+
+CookieChimp exposes properties on the `window.CookieChimp` object that tell you about the visitor's location and the banner that was served. They're useful when you want to customise behaviour or tags based on country, region, or consent mode — without duplicating banners.
+
+<Snippet file="visitor-properties.mdx" />
+
+For full end-to-end examples — including hiding a button for visitors from a specific country and firing analytics tags in opt-out regions — see [Geo-Targeted Customization](/advanced/geo-targeted-customization).

--- a/advanced/geo-targeted-customization.mdx
+++ b/advanced/geo-targeted-customization.mdx
@@ -1,0 +1,113 @@
+---
+title: "Geo-Targeted Customization"
+description: "Customize the banner and your tags per country, region, or consent mode without duplicating banners."
+---
+
+CookieChimp serves a single banner that already adapts to the visitor's location based on your geolocation rules. Sometimes, though, you'll want to layer **additional** behaviour on top of that — for example, hiding a UI element only for visitors from one country, or firing your analytics tags differently for opt-in vs. opt-out regions.
+
+You can do this by reading visitor and config properties directly from the `window.CookieChimp` object — no need to maintain a second banner.
+
+## What properties are available?
+
+<Snippet file="visitor-properties.mdx" />
+
+## Example: hide the close button for one country
+
+Some advertising platforms (e.g. WeChat Search Ads in China) require that the landing page does not "block the UX" with a forced-consent prompt. The cleanest fix is to expose a close (`×`) button on the banner — but only for visitors from that country, so you don't drop opt-in rates elsewhere.
+
+You can keep a single banner and toggle the close button visibility with a small CSS rule that's only applied when `visitorCountry` matches.
+
+### Option 1 — Inject a style tag
+
+```js
+window.addEventListener("cc:onModalReady", function () {
+  if (CookieChimp.visitorCountry === "CN") {
+    const style = document.createElement("style");
+    style.textContent = `#cc-main .cm__btn.cm__btn--close { display: none !important; }`;
+    document.head.appendChild(style);
+  }
+});
+```
+
+### Option 2 — Toggle a class on `<html>` and scope the CSS
+
+```js
+window.addEventListener("cc:onModalReady", function () {
+  if (CookieChimp.visitorCountry === "CN") {
+    document.documentElement.classList.add("cc-cn");
+  }
+});
+```
+
+```css
+.cc-cn #cc-main .cm__btn.cm__btn--close {
+  display: none !important;
+}
+```
+
+<Tip>
+  We wrap the check in `cc:onModalReady` so `CookieChimp.visitorCountry` is
+  guaranteed to be populated before we read it. See [Callbacks &
+  Events](/advanced/callbacks-events) for other events you can hook into.
+</Tip>
+
+## Example: fire analytics in opt-out regions even without consent
+
+If you've configured CookieChimp with **two consent modes** — opt-in for strict-consent countries (e.g. EU/EEA under GDPR) and opt-out for regions where pre-consent tracking is allowed (e.g. many US states) — you can use `getConfig().mode` to decide whether your analytics tag should fire before consent is granted.
+
+In opt-out regions, you'll typically want tags to fire immediately (relying on Google Consent Mode to anonymise data until the user opts out). In opt-in regions, tags should only fire after the user grants consent for the relevant category.
+
+### Push a dataLayer event when the banner is in opt-out mode
+
+```js
+document.addEventListener("cc:onModalReady", function () {
+  if (window.CookieChimp.getConfig().mode === "opt-out") {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ event: "cookiechimp_opt_out_mode" });
+  }
+});
+```
+
+### Wire it into your tag firing condition
+
+In Google Tag Manager (or Adobe Launch), add the `cookiechimp_opt_out_mode` event as an **OR** condition on your analytics tag's trigger, alongside your existing category-consent condition:
+
+1. Fire the tag **if** `CookieChimp.getConfig().mode === 'opt-out'` (the event above), **OR**
+2. Fire the tag **if** consent has been granted to the analytics category.
+
+This sends data immediately for visitors in opt-out regions while still respecting consent for visitors in opt-in regions. Because Google Consent Mode is already wired up by CookieChimp, no personal information is shared until the visitor explicitly opts in.
+
+<Warning>
+  For this to work reliably, the CookieChimp script must load **before** your
+  tag manager runs — not from inside GTM itself. See the [installation
+  guide](/installation/installation) for the recommended placement.
+</Warning>
+
+## Example: branch behaviour by US state
+
+`visitorRegion` lets you treat visitors from specific US states (or other subdivisions) differently. For example, you might want to log a custom event only for visitors from California:
+
+```js
+window.addEventListener("cc:onModalReady", function () {
+  if (
+    CookieChimp.visitorCountry === "US" &&
+    CookieChimp.visitorRegion === "CA"
+  ) {
+    // California-specific logic, e.g. show a "Do Not Sell" link
+  }
+});
+```
+
+## When should I use these properties vs. multiple banners?
+
+Use these properties when:
+
+- The cookies, services, and banner text are the **same** across regions, but you need a small UI or tag-firing tweak per region.
+- You want to keep a **single source of truth** for banner content and avoid maintaining duplicates.
+
+Configure separate banners (via geolocation rules in the dashboard) when:
+
+- The set of categories, services, or legal text genuinely differs between regions.
+- You need different default consent states (opt-in vs. opt-out) — this is already handled by CookieChimp's geolocation rules and surfaced via `getConfig().mode`.
+
+<Snippet file="install/cms-troubleshooting-footer.mdx" />

--- a/docs.json
+++ b/docs.json
@@ -126,7 +126,7 @@
               "advanced/custom-update-consent-button",
               "advanced/custom-css",
               "advanced/callbacks-events",
-              "advanced/geo-targeted-customization",
+              "advanced/banner-overrides",
               "advanced/content-security-policy"
             ]
           }

--- a/docs.json
+++ b/docs.json
@@ -126,6 +126,7 @@
               "advanced/custom-update-consent-button",
               "advanced/custom-css",
               "advanced/callbacks-events",
+              "advanced/geo-targeted-customization",
               "advanced/content-security-policy"
             ]
           }


### PR DESCRIPTION
Add reference docs for CookieChimp.visitorCountry, visitorRegion,
visitorNeedsConsent, and getConfig().mode so users can branch behaviour
per region without maintaining duplicate banners. Examples cover hiding
a banner button for one country and firing analytics in opt-out regions.