### PR TITLE
Update banner close button documentation with regulatory context

### DIFF
--- a/advanced/banner-overrides.mdx
+++ b/advanced/banner-overrides.mdx
@@ -19,7 +19,7 @@ Geo-targeted customization is the most common reason to drop down to code, but t
 
 ## Example: hide the close button for one country
 
-Some advertising platforms (e.g. WeChat Search Ads in China) require that the landing page does not "block the UX" with a forced-consent prompt. The cleanest fix is to expose a close (`×`) button on the banner — but only for visitors from that country, so you don't drop opt-in rates elsewhere.
+Some jurisdictions treat a close (`×`) button as an ambiguous signal — a visitor who dismisses the banner without an explicit accept or reject hasn't made a clear consent choice, and regulators may not consider that a valid interaction. If your default banner shows a close button, the cleanest fix is to hide it — but only for visitors from those countries, so the easier dismissal flow is preserved elsewhere.
 
 You can keep a single banner and toggle the close button visibility with a small CSS rule that's only applied when `visitorCountry` matches.
 


### PR DESCRIPTION
## Summary
Updated the documentation example in the banner overrides guide to provide more accurate regulatory context for when to hide the close button on consent banners.

## Changes
- Revised the explanation of why close buttons may need to be hidden for certain jurisdictions
- Changed the rationale from advertising platform requirements (WeChat Search Ads) to regulatory compliance concerns
- Clarified that some jurisdictions treat banner dismissal via close button as an ambiguous consent signal that may not satisfy regulatory requirements
- Emphasized that hiding the close button should only apply to affected countries while preserving the easier dismissal flow elsewhere

## Details
The updated documentation now correctly explains that regulators in certain jurisdictions may not consider a banner dismissal (via close button) without an explicit accept/reject choice as valid consent. This provides clearer guidance for developers implementing geo-targeted banner customization using the `visitorCountry` variable.

https://claude.ai/code/session_01EjSt6vAN74z83WP3jLgShL