### PR TITLE
Document cc:consentStringUpdated on the JavaScript SDK page

### DIFF
--- a/advanced/callbacks-events.mdx
+++ b/advanced/callbacks-events.mdx
@@ -155,7 +155,7 @@ CookieChimp dispatches three families of events:
 | ------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
 | [Consent events](#consent-events)                 | `cc:onFirstConsent`, `cc:onConsented`, `cc:onUpdate`                                            | When the visitor accepts, rejects, or changes preferences. |
 | [Modal events](#modal-events)                     | `cc:beforeModalShow`, `cc:onModalShow`, `cc:onModalHide`, `cc:onModalReady`                     | At each stage of the banner / preferences modal lifecycle. |
-| [Consent string events](#consent-string-events)   | `cc:consentStringUpdated`                                                                       | When `window.cookieChimpConsentString` is (re)built — useful for tag managers like Adobe Launch and Google Tag Manager. |
+| [Consent string events](#consent-string-events)   | `cc:consentStringUpdated`                                                                       | When `window.cookieChimpConsentString` is (re)built — used by the [Adobe Launch](/installation/adobe-launch) integration. |
 
 ### Consent events
 
@@ -286,7 +286,13 @@ The data carried by each modal event:
 
 ### Consent string events
 
-CookieChimp also publishes the visitor's choices as a flat, comma-separated string on `window.cookieChimpConsentString`. This is the easiest way to gate tags in Adobe Launch, Google Tag Manager, or any other tag manager that prefers a single value over the structured `getUserPreferences()` object.
+CookieChimp also publishes the visitor's choices as a flat, comma-separated string on `window.cookieChimpConsentString`. The [Adobe Launch](/installation/adobe-launch) integration is built on this property and the matching event below — it pairs well with any setup that prefers a single value over the structured `getUserPreferences()` object.
+
+<Note>
+  Google Tag Manager uses its own consent signal — a `cookiechimp_consent_update`
+  push on `dataLayer`, not this DOM event. See the [Google Tag
+  Manager](/installation/google-tag-manager) guide for the GTM-specific setup.
+</Note>
 
 #### `window.cookieChimpConsentString`
 

--- a/advanced/callbacks-events.mdx
+++ b/advanced/callbacks-events.mdx
@@ -149,7 +149,17 @@ if (CookieChimp.validConsent()) {
 
 Every event is a standard DOM event dispatched on `window`. Subscribe with `window.addEventListener` and read the data from `event.detail`.
 
+CookieChimp dispatches three families of events:
+
+| Category                                          | Events                                                                                          | When they fire                                              |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| [Consent events](#consent-events)                 | `cc:onFirstConsent`, `cc:onConsented`, `cc:onUpdate`                                            | When the visitor accepts, rejects, or changes preferences. |
+| [Modal events](#modal-events)                     | `cc:beforeModalShow`, `cc:onModalShow`, `cc:onModalHide`, `cc:onModalReady`                     | At each stage of the banner / preferences modal lifecycle. |
+| [Consent string events](#consent-string-events)   | `cc:consentStringUpdated`                                                                       | When `window.cookieChimpConsentString` is (re)built — useful for tag managers like Adobe Launch and GTM. |
+
 ### Consent events
+
+These fire whenever the visitor's consent state changes — give consent, reload the page with stored consent, or change their preferences from the privacy trigger.
 
 #### `cc:onFirstConsent`
 
@@ -203,6 +213,8 @@ The data carried by each consent event:
 | `detail.changedServices`  | `cc:onUpdate`               | Object of services whose acceptance changed, keyed by category.          |
 
 ### Modal events
+
+These cover the lifecycle of the consent banner and preferences modal — from being attached to the DOM to being shown and hidden.
 
 #### `cc:beforeModalShow`
 
@@ -271,6 +283,43 @@ The data carried by each modal event:
 | Property           | Description                                                       |
 | ------------------ | ----------------------------------------------------------------- |
 | `detail.modalName` | The name of the modal that triggered the event (e.g. the consent or preferences modal). |
+
+### Consent string events
+
+CookieChimp also publishes the visitor's choices as a flat, comma-separated string on `window.cookieChimpConsentString`. This is the easiest way to gate tags in Adobe Launch, Google Tag Manager, or any other tag manager that prefers a single value over the structured `getUserPreferences()` object.
+
+#### `window.cookieChimpConsentString`
+
+A comma-separated list of every category and service the visitor has accepted, for example:
+
+```js
+window.cookieChimpConsentString;
+// => 'essential,analytics,marketing,Google Analytics,Hotjar,Facebook Pixel'
+```
+
+The string is rebuilt every time the visitor's consent changes, so reading it inside a `cc:consentStringUpdated` listener (below) always reflects the latest state.
+
+#### `cc:consentStringUpdated`
+
+Triggered once consent has been granted and again every time the visitor changes their preferences, after `window.cookieChimpConsentString` has been rebuilt.
+
+```js
+window.addEventListener("cc:consentStringUpdated", function () {
+  // window.cookieChimpConsentString is up to date here
+  var consent = window.cookieChimpConsentString || "";
+
+  if (consent.split(",").indexOf("Google Analytics") !== -1) {
+    // "Google Analytics" was accepted — fire the tag
+  }
+});
+```
+
+<Tip>
+  Tag managers usually need both pieces — read `window.cookieChimpConsentString`
+  on page load to handle visitors who already consented on a previous visit, and
+  listen for `cc:consentStringUpdated` to handle real-time changes. See the
+  [Adobe Launch](/installation/adobe-launch) guide for a complete recipe.
+</Tip>
 
 ## Controlling the banner
 

--- a/advanced/callbacks-events.mdx
+++ b/advanced/callbacks-events.mdx
@@ -155,11 +155,11 @@ CookieChimp dispatches three families of events:
 | ------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
 | [Consent events](#consent-events)                 | `cc:onFirstConsent`, `cc:onConsented`, `cc:onUpdate`                                            | When the visitor accepts, rejects, or changes preferences. |
 | [Modal events](#modal-events)                     | `cc:beforeModalShow`, `cc:onModalShow`, `cc:onModalHide`, `cc:onModalReady`                     | At each stage of the banner / preferences modal lifecycle. |
-| [Consent string events](#consent-string-events)   | `cc:consentStringUpdated`                                                                       | When `window.cookieChimpConsentString` is (re)built — useful for tag managers like Adobe Launch and GTM. |
+| [Consent string events](#consent-string-events)   | `cc:consentStringUpdated`                                                                       | When `window.cookieChimpConsentString` is (re)built — useful for tag managers like Adobe Launch and Google Tag Manager. |
 
 ### Consent events
 
-These fire whenever the visitor's consent state changes — give consent, reload the page with stored consent, or change their preferences from the privacy trigger.
+These fire whenever the visitor's consent state changes. For example, when the visitor gives consent for the first time, reloads a page on which consent is already stored, or changes their preferences from the privacy trigger.
 
 #### `cc:onFirstConsent`
 


### PR DESCRIPTION
## Summary

- Adds the `cc:consentStringUpdated` event and the `window.cookieChimpConsentString` property to `advanced/callbacks-events.mdx`, which were previously only mentioned on the Adobe Launch installation page.
- Reorganises the event reference into three named categories — Consent events, Modal events, Consent string events — and introduces an overview table so every event the SDK dispatches is discoverable from the JavaScript SDK page.
- Links the new section to the Adobe Launch guide so readers can find the end-to-end tag-manager recipe.

## Test plan

- [ ] Render `advanced/callbacks-events.mdx` and confirm the new "Consent string events" section appears under "Listening for events".
- [ ] Confirm the overview table at the top of "Listening for events" lists all three categories and links to each.
- [ ] Confirm anchor links from other pages (e.g. `/advanced/callbacks-events#listening-for-events`) still resolve.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Esac9KeuGhCPrd94GSNAku)_